### PR TITLE
Required version of Railties does not exist yet. Maybe this is what was meant?

### DIFF
--- a/sprockets-rails.gemspec
+++ b/sprockets-rails.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_runtime_dependency "sprockets", "~> 2.4.1"
-  s.add_runtime_dependency "railties",  ">= 4.0.0.beta", '< 5.0'
+  s.add_runtime_dependency "railties",  ">= 3.0.0", '< 4.0'
 end


### PR DESCRIPTION
The gemspec requires version 4 beta or greater of Railties. This doesn't seem to exist: http://rubygems.org/gems/railties
