### PR TITLE
Make sure that javascript_include_tag/stylesheet_link_tag methods discard repeated assets

### DIFF
--- a/lib/sprockets/rails/helpers/rails_helper.rb
+++ b/lib/sprockets/rails/helpers/rails_helper.rb
@@ -32,7 +32,7 @@ module Sprockets
             else
               super(source.to_s, { :src => path_to_asset(source, :ext => 'js', :body => body, :digest => digest) }.merge!(options))
             end
-          end.join("\n").html_safe
+          end.uniq.join("\n").html_safe
         end
 
         def stylesheet_link_tag(*sources)
@@ -49,7 +49,7 @@ module Sprockets
             else
               super(source.to_s, { :href => path_to_asset(source, :ext => 'css', :body => body, :protocol => :request, :digest => digest) }.merge!(options))
             end
-          end.join("\n").html_safe
+          end.uniq.join("\n").html_safe
         end
 
         def asset_path(source, options = {})

--- a/test/sprockets_helper_test.rb
+++ b/test/sprockets_helper_test.rb
@@ -251,6 +251,9 @@ class SprocketsHelperTest < ActiveSupport::TestCase
     assert_match %r{<script src="/assets/jquery.plugin.js"></script>},
       javascript_include_tag('jquery.plugin', :digest => false)
 
+    assert_match %r{\A<script src="/assets/xmlhr-[0-9a-f]+.js"></script>\Z},
+      javascript_include_tag("xmlhr", "xmlhr")
+
     @config.assets.compile = true
     @config.assets.debug = true
     assert_match %r{<script src="/javascripts/application.js"></script>},
@@ -297,6 +300,9 @@ class SprocketsHelperTest < ActiveSupport::TestCase
 
     assert_match %r{<link href="/assets/style-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/application-[0-9a-f]+.css\?body=1" media="screen" rel="stylesheet" />},
       stylesheet_link_tag(:application, :debug => true)
+
+    assert_match %r{\A<link href="/assets/style-[0-9a-f]+.css" media="screen" rel="stylesheet" />\Z},
+      stylesheet_link_tag("style", "style")
 
     @config.assets.compile = true
     @config.assets.debug = true


### PR DESCRIPTION
Ensure that these helper methods include only once every asset.

Actually, this is the behavior when you create a rails app without sprockets_rails (with the flag --skip-sprocket)

Discussion related here: https://github.com/rails/rails/pull/6149
