### PR TITLE
Don't compile nondigest assets in separate process

### DIFF
--- a/lib/sprockets/rails/bootstrap.rb
+++ b/lib/sprockets/rails/bootstrap.rb
@@ -1,6 +1,8 @@
 module Sprockets
   module Rails
     class Bootstrap
+      cattr_accessor :original_assets
+
       def initialize(app)
         @app = app
       end
@@ -33,6 +35,7 @@ module Sprockets
         end
 
         if config.assets.digest
+          self.class.original_assets = app.assets
           app.assets = app.assets.index
         end
       end


### PR DESCRIPTION
Before this patch rake task for compiling assets was running separate
process to compile nondigest assets, instead of just invoking the task
in the same process. In order to make it work without having 2 processes
we need to clear sprockets cache, which is impossible with
`Sprockets::Index` - it's immutable. That's why I'm making a copy of
`Environment` before converting it to index, to be able to clear the
cache and use it for nondigest version. It's a bit hacky, but since
`Index` just references most of the things in `Environment` it should
work just fine.
