### PR TITLE
Remove manifest option

### DIFF
--- a/lib/sprockets-rails/tasks/assets.rake
+++ b/lib/sprockets-rails/tasks/assets.rake
@@ -59,7 +59,6 @@ namespace :assets do
       compiler = Sprockets::Rails::StaticCompiler.new(env,
                                                       target,
                                                       config.assets.precompile,
-                                                      :manifest_path => config.assets.manifest,
                                                       :digest => config.assets.digest,
                                                       :manifest => digest.nil?)
       compiler.compile

--- a/lib/sprockets/rails/railtie.rb
+++ b/lib/sprockets/rails/railtie.rb
@@ -33,14 +33,9 @@ module Sprockets
           end
         end
 
-        if config.assets.manifest
-          path = File.join(config.assets.manifest, "manifest.yml")
-        else
-          path = File.join(::Rails.public_path, config.assets.prefix, "manifest.yml")
-        end
-
-        if File.exist?(path)
-          config.assets.digests = YAML.load_file(path)
+        manifest_path = File.join(::Rails.public_path, config.assets.prefix, "manifest.yml")
+        if File.exist?(manifest_path)
+          config.assets.digests = YAML.load_file(manifest_path)
         end
 
         ActiveSupport.on_load(:action_view) do

--- a/lib/sprockets/rails/static_compiler.rb
+++ b/lib/sprockets/rails/static_compiler.rb
@@ -11,7 +11,6 @@ module Sprockets
         @paths = paths
         @digest = options.fetch(:digest, true)
         @manifest = options.fetch(:manifest, true)
-        @manifest_path = options.delete(:manifest_path) || target
         @zip_files = options.delete(:zip_files) || /\.(?:css|html|js|svg|txt|xml)$/
       end
 
@@ -26,8 +25,8 @@ module Sprockets
       end
 
       def write_manifest(manifest)
-        FileUtils.mkdir_p(@manifest_path)
-        File.open("#{@manifest_path}/manifest.yml", 'wb') do |f|
+        FileUtils.mkdir_p(@target)
+        File.open("#{@target}/manifest.yml", 'wb') do |f|
           YAML.dump(manifest, f)
         end
       end

--- a/test/assets_test.rb
+++ b/test/assets_test.rb
@@ -141,21 +141,6 @@ module ApplicationTests
       assert_match(/application-([0-z]+)\.css/, assets["application.css"])
     end
 
-    test "precompile creates a manifest file in a custom path with all the assets listed" do
-      app_file "app/assets/stylesheets/application.css.erb", "<%= asset_path('rails.png') %>"
-      app_file "app/assets/javascripts/application.js", "alert();"
-      # digest is default in false, we must enable it for test environment
-      add_to_config "config.assets.digest = true"
-      add_to_config "config.assets.manifest = '#{app_path}/shared'"
-
-      precompile!
-      manifest = "#{app_path}/shared/manifest.yml"
-
-      assets = YAML.load_file(manifest)
-      assert_match(/application-([0-z]+)\.js/, assets["application.js"])
-      assert_match(/application-([0-z]+)\.css/, assets["application.css"])
-    end
-
     test "the manifest file should be saved by default in the same assets folder" do
       app_file "app/assets/javascripts/application.js", "alert();"
       # digest is default in false, we must enable it for test environment


### PR DESCRIPTION
Sprockets don't have option for configure where to write
manifest file. It's one of causes why we cannot use rake task
provided by sprockets for now.

After discuss there https://github.com/rails/sprockets-rails/issues/9
/cc @guilleiguaran @josevalim
