### PR TITLE
Respect `config.digest = false` for `asset_path`

### DIFF
--- a/lib/sprockets/rails/helpers/rails_helper.rb
+++ b/lib/sprockets/rails/helpers/rails_helper.rb
@@ -150,7 +150,9 @@ module Sprockets
             if source[0] == ?/
               source
             else
-              source = digest_for(source) unless options[:digest] == false
+              if digest_assets && options[:digest] != false
+                source = digest_for(source)
+              end
               source = File.join(dir, source)
               source = "/#{source}" unless source =~ /^\//
               source

--- a/test/sprockets_helper_test.rb
+++ b/test/sprockets_helper_test.rb
@@ -357,4 +357,12 @@ class SprocketsHelperTest < ActiveSupport::TestCase
     assert_equal '/assets/logo.png',
       asset_path("logo.png")
   end
+
+  test "`config.digest = false` works with `config.compile = false`" do
+    @config.assets.digest = false
+    @config.assets.compile = false
+
+    assert_equal '/assets/logo.png',
+      asset_path("logo.png")
+  end
 end


### PR DESCRIPTION
Previously, the `asset_path` internals only respected the `:digest` option,
but ignored the global config setting. This meant that
`config.digest = false` could not be used in conjunction with
`config.compile = false` this corrects the behavior.
