### PR TITLE
Ensure assets aren't duplicated for debug. #31

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -95,7 +95,7 @@ module Sprockets
             else
               super(source, options)
             end
-          }.join("\n").html_safe
+          }.flatten.uniq.join("\n").html_safe
         else
           sources.push(options)
           super(*sources)
@@ -117,7 +117,7 @@ module Sprockets
             else
               super(source, options)
             end
-          }.join("\n").html_safe
+          }.flatten.uniq.join("\n").html_safe
         else
           sources.push(options)
           super(*sources)

--- a/test/fixtures/dependency.css
+++ b/test/fixtures/dependency.css
@@ -1,0 +1,1 @@
+/* dependency */

--- a/test/fixtures/dependency.js
+++ b/test/fixtures/dependency.js
@@ -1,0 +1,1 @@
+// dependency

--- a/test/fixtures/file1.css
+++ b/test/fixtures/file1.css
@@ -1,0 +1,2 @@
+/*= require dependency
+ */

--- a/test/fixtures/file1.js
+++ b/test/fixtures/file1.js
@@ -1,0 +1,1 @@
+//= require dependency

--- a/test/fixtures/file2.css
+++ b/test/fixtures/file2.css
@@ -1,0 +1,2 @@
+/*= require dependency
+ */

--- a/test/fixtures/file2.js
+++ b/test/fixtures/file2.js
@@ -1,0 +1,1 @@
+//= require dependency

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -296,6 +296,8 @@ class DebugHelperTest < NoHostHelperTest
       @view.javascript_include_tag(:foo)
     assert_equal %(<script src="/assets/foo.js?body=1"></script>\n<script src="/assets/bar.js?body=1"></script>),
       @view.javascript_include_tag(:bar)
+    assert_equal %(<script src="/assets/dependency.js?body=1"></script>\n<script src="/assets/file1.js?body=1"></script>\n<script src="/assets/file2.js?body=1"></script>),
+      @view.javascript_include_tag(:file1, :file2)
   end
 
   def test_stylesheet_link_tag
@@ -305,6 +307,8 @@ class DebugHelperTest < NoHostHelperTest
       @view.stylesheet_link_tag(:foo)
     assert_equal %(<link href="/assets/foo.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/bar.css?body=1" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag(:bar)
+    assert_equal %(<link href="/assets/dependency.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file1.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file2.css?body=1" media="screen" rel="stylesheet" />),
+      @view.stylesheet_link_tag(:file1, :file2)
   end
 
   def test_javascript_path


### PR DESCRIPTION
When debug=true assets can require the same file multiple times -- this ensures that even if several files are included using javascript_include_tag only one dependency file will ever be included (even if multiple files require it).
