### PR TITLE
Add lib and vendor to loose assets.

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -36,7 +36,7 @@ end
 module Sprockets
   class Railtie < ::Rails::Railtie
     LOOSE_APP_ASSETS = lambda do |path, filename|
-      filename =~ /app\/assets/ && !%w(.js .css).include?(File.extname(path))
+      filename =~ /(app|lib|vendor)\/assets/ && !%w(.js .css).include?(File.extname(path))
     end
 
     class OrderedOptions < ActiveSupport::OrderedOptions


### PR DESCRIPTION
- Some gems locate loose assets in lib/assets or vendor/assets
- This change picks them up so they are processed during `rake assets:precompile`

Examples:

* https://github.com/thomas-mcdonald/bootstrap-sass/tree/master/vendor/assets/images
* https://github.com/joliss/jquery-ui-rails/tree/master/vendor/assets/images
