### PR TITLE
Ensure precompile setting from app is applied to rake task.

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -61,7 +61,7 @@ module Sprockets
       Sprockets::Rails::Task.new do |t|
         t.environment = lambda { app.assets }
         t.output      = File.join(app.root, 'public', app.config.assets.prefix)
-        t.assets      = app.config.assets.precompile
+        t.assets      = lambda { app.config.assets.precompile }
         t.cache_path  = "#{app.config.root}/tmp/cache/assets"
       end
     end


### PR DESCRIPTION
I was not able to use the precompile setting to solve the situation described here:
#34

This is due to the details below:

Rails calls load_tasks prior to the app's configure block.
This results in the sprockets rake task being initialized without the app's assets.precompile setting.

This change lazily evaluates the assets setting on the sprockets rake task so they will reflect the eventual assets.precompile setting.

With this change, loose assets in lib or vendor from a legacy gem will now be picked up if they are explicitly specified in the precompile setting.

This is dependent upon https://github.com/sstephenson/sprockets/pull/404
