### PR TITLE
Ensure precompile setting from app is applied to rake task.

### DIFF
--- a/lib/sprockets/rails/task.rb
+++ b/lib/sprockets/rails/task.rb
@@ -19,7 +19,7 @@ module Sprockets
           desc "Compile all the assets named in config.assets.precompile"
           task :precompile => :environment do
             with_logger do
-              manifest.compile(assets)
+              manifest.compile(::Rails.application.config.assets.precompile)
             end
           end
 


### PR DESCRIPTION
See the previous long thread on this here: https://github.com/rails/sprockets-rails/pull/36

This commit actually does fix the rake task so you can precompile assets again in Rails 4.
