### PR TITLE
Refactoring assets method to remove an unnecessary return statement.

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -19,9 +19,7 @@ module Rails
 
     # Returns Sprockets::Environment for app config.
     def assets
-      return @assets if defined? @assets
-
-      @assets = Sprockets::Environment.new(root.to_s) do |env|
+      @assets ||= Sprockets::Environment.new(root.to_s) do |env|
         env.version = ::Rails.env
 
         path = "#{config.root}/tmp/cache/assets/#{::Rails.env}"


### PR DESCRIPTION
There's a portion of the code which doesn't actually need a return statement. I've refactored it so that the code doesn't need to explicitly make a call to `defined?`. 
