### PR TITLE
Allow setting config.assets.precompile in per-environment configurations

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -62,7 +62,7 @@ module Sprockets
       Sprockets::Rails::Task.new do |t|
         t.environment = lambda { app.assets }
         t.output      = File.join(app.root, 'public', app.config.assets.prefix)
-        t.assets      = app.config.assets.precompile
+        t.assets      = lambda { app.config.assets.precompile }
         t.cache_path  = "#{app.config.root}/tmp/cache/assets"
       end
     end


### PR DESCRIPTION
Sorry that this basically just duplicates #36, but I've seen several people running into the issue lately where they try to use `config.assets.precompile` in `environments/production.rb`, and wonder why it doesn't take effect.

As has been discussed in #36, this lazy-evaluation isn't ideal, but I suggest fixing this issue now while waiting for the ideal solution.
