### PR TITLE
Fixed support of Rails 3.0.x rake tasks definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
 tmp/
 *.gem
+test/gemfiles/*.lock

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -59,6 +59,8 @@ module Sprockets
     rake_tasks do |app|
       require 'sprockets/rails/task'
 
+      app ||= ::Rails.application
+
       Sprockets::Rails::Task.new do |t|
         t.environment = lambda { app.assets }
         t.output      = File.join(app.root, 'public', app.config.assets.prefix)

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -33,6 +33,10 @@ class TestBoot < Test::Unit::TestCase
   def test_initialize
     app.initialize!
   end
+
+  def test_load_tasks
+    app.load_tasks
+  end
 end
 
 class TestRailtie < TestBoot


### PR DESCRIPTION
In order current code is not support Rails 3.0.x.:

To define tasks sprocket-rails use `app`: https://github.com/jetthoughts/sprockets-rails/blob/master/lib/sprockets/railtie.rb#L59

But for rails `3.0.stable`: https://github.com/rails/rails/blob/3-0-stable/railties/lib/rails/railtie.rb#L185

There is no any `app` arguments for rake tasks blocks.
