### PR TITLE
Resolved bundler deprecation warning about rubygems source.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-Gemfile.lock
+Gemfile*.lock
 tmp/
 *.gem

--- a/test/gemfiles/Gemfile.rails-3.0.x
+++ b/test/gemfiles/Gemfile.rails-3.0.x
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec :path => "./../.."
 
 gem "actionpack", "~> 3.0.0"

--- a/test/gemfiles/Gemfile.rails-3.1.x
+++ b/test/gemfiles/Gemfile.rails-3.1.x
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec :path => "./../.."
 
 # Patch 3-1-stable to allow new sprockets

--- a/test/gemfiles/Gemfile.rails-3.2.x
+++ b/test/gemfiles/Gemfile.rails-3.2.x
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec :path => "./../.."
 
 gem "actionpack", "~> 3.2.0"

--- a/test/gemfiles/Gemfile.rails-4.0.x
+++ b/test/gemfiles/Gemfile.rails-4.0.x
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec :path => "./../.."
 
 # gem "actionpack", "~> 4.0.0"

--- a/test/gemfiles/Gemfile.rails-edge
+++ b/test/gemfiles/Gemfile.rails-edge
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec :path => "./../.."
 
 gem 'actionpack', :github => 'rails/rails'


### PR DESCRIPTION
Resolved for test Gemfiles bundler's deprecation warnings:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
