### PR TITLE
Rails 3.2 is not supportable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
 gemfile:
   - test/gemfiles/Gemfile.rails-3.0.x
   - test/gemfiles/Gemfile.rails-3.1.x
-  - test/gemfiles/Gemfile.rails-3.2.x
   - test/gemfiles/Gemfile.rails-4.0.x
   - test/gemfiles/Gemfile.rails-edge
 

--- a/test/gemfiles/Gemfile.rails-3.2.x
+++ b/test/gemfiles/Gemfile.rails-3.2.x
@@ -1,6 +1,0 @@
-source :rubygems
-gemspec :path => "./../.."
-
-gem "actionpack", "~> 3.2.0"
-gem "railties", "~> 3.2.0"
-gem "tzinfo"


### PR DESCRIPTION
In order that sprocket-rails was extracted from rails 3.2, there is still sprocket railtie embedded in rails 3.2

For now 3.2 better to remove from Travis CI configuration to test 3.2 rails compatibility.
