### PR TITLE
Added json gem to dependencies

### DIFF
--- a/sprockets-rails.gemspec
+++ b/sprockets-rails.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sprockets", "~> 2.8"
   s.add_dependency "actionpack", ">= 3.0"
   s.add_dependency "activesupport", ">= 3.0"
+  s.add_development_dependency "json"
   s.add_development_dependency "rake"
 
   s.author = "Joshua Peek"


### PR DESCRIPTION
Added json gem to dev dependency in order to remove warning for tests:

```
You are using an old or stdlib version of json gem
Please upgrade to the recent version by adding this to your Gemfile:

  gem 'json', '~> 1.7.7'
```
