### PR TITLE
Warn if not compiling in production mode

### DIFF
--- a/lib/sprockets/rails/task.rb
+++ b/lib/sprockets/rails/task.rb
@@ -19,7 +19,11 @@ module Sprockets
           desc "Compile all the assets named in config.assets.precompile"
           task :precompile => :environment do
             with_logger do
-              manifest.compile(assets)
+              if ::Rails.env.production?
+                manifest.compile(assets)
+              else
+                puts "Assets should now only be compiled in production mode. Re-run with RAILS_ENV=production."
+              end
             end
           end
 


### PR DESCRIPTION
Rails now needs to be in production mode for asset precompilation. I've added a warning message and prevented compilation if you're in anything else. See rails/rails#10551 for my rails bug report and discussion.
