### PR TITLE
Add LICENSE to .gemspec

### DIFF
--- a/sprockets-rails.gemspec
+++ b/sprockets-rails.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.summary  = "Sprockets Rails integration"
   s.license  = "MIT"
 
-  s.files = Dir["README.md", "lib/**/*.rb"]
+  s.files = Dir["README.md", "lib/**/*.rb", "LICENSE"]
 
   s.add_dependency "sprockets", "~> 2.8"
   s.add_dependency "actionpack", ">= 3.0"


### PR DESCRIPTION
This will include the LICENSE file in the distributed .gem which will help us when distributing the gem as RPM in Fedora [1]. Given the note in README:

```
Released under the MIT license. See `LICENSE` for details.
```

This won't be confusing for people using the final gem file.

Please merge, thank you.

[1] https://fedoraproject.org/wiki/Packaging:LicensingGuidelines
