### PR TITLE
Handle when the params hash is unavailable in a mailer

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -129,6 +129,8 @@ module Sprockets
         # and replaced by source maps in Sprockets 3.x.
         def request_debug_assets?
           debug_assets || (defined?(controller) && controller && params[:debug_assets])
+        rescue NoMethodError
+          return false
         end
 
         # Internal method to support multifile debugging. Will


### PR DESCRIPTION
This was an issue previously fixed in Rails under this commit: https://github.com/rails/rails/commit/dbca49b, but seems to have regressed here as it is occurring for me in production only, and this patch fixes this issue. 

The exception raised was:

```
ActionView::Template::Error: undefined method `params' for #<DeliveryNotifier:0x007fba86ae3d58>
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/action_view/helpers/controller_helper.rb:10:in `params'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/sprockets-rails-2.0.0/lib/sprockets/rails/helper.rb:130:in `request_debug_assets?'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/sprockets-rails-2.0.0/lib/sprockets/rails/helper.rb:110:in `stylesheet_link_tag'
    from /Users/jmd/code/layervault/delivery/app/views/layouts/email.html.erb:6:in `_app_views_layouts_email_html_erb__39917267253385526_70219528239640'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/action_view/template.rb:143:in `block in render'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/activesupport-4.0.0/lib/active_support/notifications.rb:161:in `instrument'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/action_view/template.rb:141:in `render'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/action_view/renderer/template_renderer.rb:61:in `render_with_layout'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/action_view/renderer/template_renderer.rb:47:in `render_template'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/action_view/renderer/template_renderer.rb:17:in `render'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/action_view/renderer/renderer.rb:42:in `render_template'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/action_view/renderer/renderer.rb:23:in `render'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/abstract_controller/rendering.rb:127:in `_render_template'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/abstract_controller/rendering.rb:120:in `render_to_body'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/abstract_controller/rendering.rb:97:in `render'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionmailer-4.0.0/lib/action_mailer/base.rb:755:in `block in collect_responses'
... 6 levels...
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/abstract_controller/callbacks.rb:18:in `block in process_action'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/activesupport-4.0.0/lib/active_support/callbacks.rb:373:in `_run__545462918236281647__process_action__callbacks'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/activesupport-4.0.0/lib/active_support/callbacks.rb:80:in `run_callbacks'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/abstract_controller/callbacks.rb:17:in `process_action'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/abstract_controller/base.rb:136:in `process'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionpack-4.0.0/lib/abstract_controller/rendering.rb:44:in `process'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionmailer-4.0.0/lib/action_mailer/base.rb:503:in `process'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionmailer-4.0.0/lib/action_mailer/base.rb:497:in `initialize'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionmailer-4.0.0/lib/action_mailer/base.rb:480:in `new'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/actionmailer-4.0.0/lib/action_mailer/base.rb:480:in `method_missing'
    from (irb):1
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/railties-4.0.0/lib/rails/commands/console.rb:90:in `start'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/railties-4.0.0/lib/rails/commands/console.rb:9:in `start'
    from /Users/jmd/.rbenv/versions/2.0.0-p247/lib/ruby/gems/2.0.0/gems/railties-4.0.0/lib/rails/commands.rb:64:in `<top (required)>'
    from ./bin/rails:4:in `require'
    from ./bin/rails:4:in `<main>'irb(main):002:0> exit
```

Running on Rails 4.0.0 and Ruby 2.0-p247
