### PR TITLE
Fix config.assets.cache_store not working anymore

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -22,8 +22,14 @@ module Rails
       @assets ||= Sprockets::Environment.new(root.to_s) do |env|
         env.version = ::Rails.env
 
-        path = "#{config.root}/tmp/cache/assets/#{::Rails.env}"
-        env.cache = Sprockets::Cache::FileStore.new(path)
+        if config.assets.cache_store
+          env.cache = ActiveSupport::Cache.lookup_store(config.assets.cache_store)
+        end
+
+        unless env.cache
+          path = "#{config.root}/tmp/cache/assets/#{::Rails.env}"
+          env.cache = Sprockets::Cache::FileStore.new(path)
+        end
 
         env.context_class.class_eval do
           include ::Sprockets::Rails::Helper

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -162,4 +162,21 @@ class TestRailtie < TestBoot
     assert_equal false, env.context_class.digest_assets
     assert_equal nil, env.context_class.config.asset_host
   end
+
+  def test_cache_file_store
+    app.initialize!
+
+    assert env = app.assets
+    assert env.cache.is_a? Sprockets::Cache::FileStore
+  end
+
+  def test_cache_memory_store
+    app.configure do
+      config.assets.cache_store = :memory_store
+    end
+    app.initialize!
+
+    assert env = app.assets
+    assert env.cache.is_a? ActiveSupport::Cache::MemoryStore
+  end
 end


### PR DESCRIPTION
In Rails 3.2 setting `config.assets.cache_store` would allow changing the cache store sprockets used. This feature was removed when sprockets was ported to a separate repository (for reasons unknown to me). I've added it back as well as added tests for it.

I had to `bundle exec rake test` to get the tests to pick up my changes to the railtie.

For environments without the option of a shared tmp directory, this speeds up asset compilation by 4 times in some scenarios (from 66 seconds to 16). Or on my local machine, 16 seconds to 5 (if you subtract out the 4.5 seconds it takes rails to boot on my local, that's a significant improvement: 12 seconds down to <1).  ![](http://erc.bz/xwQM.jpg)

**Edit:** By shared tmp directory I mean a persisted tmp directory across deploys (e.g. Heroku doesn't have a persisted tmp directory).
