### PR TITLE
fix no method error rescue

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -129,7 +129,7 @@ module Sprockets
         # and replaced by source maps in Sprockets 3.x.
         def request_debug_assets?
           debug_assets || (defined?(controller) && controller && params[:debug_assets])
-        rescue NoMethodError
+        rescue
           return false
         end
 


### PR DESCRIPTION
the rescue block did not properly catch the exception raised.
