### PR TITLE
Restore config.assets.manifest option.

### DIFF
--- a/lib/sprockets/rails/task.rb
+++ b/lib/sprockets/rails/task.rb
@@ -10,6 +10,9 @@ module Sprockets
       def initialize(app = nil)
         self.app = app
         super()
+        if app
+          @manifest = lambda { Sprockets::Manifest.new(index, output, app.config.assets.manifest) }
+        end
       end
 
       def environment

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -55,6 +55,7 @@ module Sprockets
     config.assets.debug      = false
     config.assets.compile    = true
     config.assets.digest     = false
+    config.assets.manifest   = nil
 
     rake_tasks do |app|
       require 'sprockets/rails/task'
@@ -64,7 +65,8 @@ module Sprockets
     config.after_initialize do |app|
       config = app.config
 
-      manifest_path = File.join(app.root, 'public', config.assets.prefix)
+      assets_dir = File.join(app.root, 'public', config.assets.prefix)
+      manifest_file_path = config.assets.manifest
 
       unless config.assets.version.blank?
         app.assets.version += "-#{config.assets.version}"
@@ -91,9 +93,9 @@ module Sprockets
 
         if config.assets.compile
           self.assets_environment = app.assets
-          self.assets_manifest    = Sprockets::Manifest.new(app.assets, manifest_path)
+          self.assets_manifest    = Sprockets::Manifest.new(app.assets, assets_dir, manifest_file_path)
         else
-          self.assets_manifest = Sprockets::Manifest.new(manifest_path)
+          self.assets_manifest = Sprockets::Manifest.new(assets_dir, manifest_file_path)
         end
       end
 

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -162,4 +162,26 @@ class TestRailtie < TestBoot
     assert_equal false, env.context_class.digest_assets
     assert_equal nil, env.context_class.config.asset_host
   end
+
+  def test_manifest_option_when_compile_is_true
+    manifest_path = File.join(Dir.pwd, 'foobar', "manifest-#{SecureRandom.hex(16)}.json")
+    app.configure do
+      config.assets.compile = true
+      config.assets.manifest = manifest_path
+    end
+    app.initialize!
+
+    assert_match manifest_path, ActionView::Base.assets_manifest.path
+  end
+
+  def test_manifest_option_when_compile_is_false
+    manifest_path = File.join(Dir.pwd, 'foobar', "manifest-#{SecureRandom.hex(16)}.json")
+    app.configure do
+      config.assets.compile = false
+      config.assets.manifest = manifest_path
+    end
+    app.initialize!
+
+    assert_match manifest_path, ActionView::Base.assets_manifest.path
+  end
 end


### PR DESCRIPTION
Took a stab to restore config.assets.manifest option meant for Rails 4.
