### PR TITLE
Allow users to skip asset dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Also see [Sprockets::Rails::Task](https://github.com/josh/sprockets-rails/blob/m
 
 Add additional assets to compile on deploy. Defaults to `application.js`, `application.css` and any other non-js/css file under `app/assets`.
 
+**`config.assets.raise_runtime_errors`**
+
+Set to `true` to enable additional runtime error checking. Recommended in the `development` environment to minimize unexpected behavior when deploying to `production`.
+
 **`config.assets.paths`**
 
 Add additional load paths to this Array. Rails includes `app/assets` and `vendor/assets` for you already. Plugins might want to add their custom paths to to this.

--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -5,6 +5,11 @@ require 'active_support/core_ext/class/attribute'
 module Sprockets
   module Rails
     module Helper
+      # support for Ruby 1.9.3 && Rails 3.0.x
+      @_config = ActiveSupport::InheritableOptions.new({}) unless defined?(ActiveSupport::Configurable::Configuration)
+      include ActiveSupport::Configurable
+      config_accessor :raise_runtime_errors
+
       class DependencyError < StandardError
         def initialize(path, dep)
           msg = "Asset depends on '#{dep}' to generate properly but has not declared the dependency\n"
@@ -139,7 +144,7 @@ module Sprockets
 
         # Checks if the asset is included in the dependencies list.
         def check_dependencies!(dep)
-          if !_dependency_assets.detect { |asset| asset.include?(dep) }
+          if raise_runtime_errors && !_dependency_assets.detect { |asset| asset.include?(dep) }
             raise DependencyError.new(self.pathname, dep)
           end
         end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -113,6 +113,8 @@ module Sprockets
         app.assets = app.assets.index
       end
 
+      Sprockets::Rails::Helper.raise_runtime_errors = app.config.assets.raise_runtime_errors
+
       if config.assets.compile
         if app.routes.respond_to?(:prepend)
           app.routes.prepend do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -385,8 +385,12 @@ end
 
 class ErrorsInHelpersTest < HelperTest
   def test_dependency_error
+    @view.raise_runtime_errors = true
     assert_raise Sprockets::Rails::Helper::DependencyError do
       @assets['error/dependency.js'].to_s
     end
+
+    @view.raise_runtime_errors = false
+    @assets['error/dependency.js'].to_s
   end
 end


### PR DESCRIPTION
Similar to #84 we want to give users the option of not running these tests. 

Related but not covered here, the case where an asset in a gem is missing a dependency: https://github.com/schneems/sprockets_better_errors/issues/5

Adding the ability to at least stop the check from occurring would give developers the ability to continue to develop even if a Gem does not update their sprockets dependencies.
