### PR TITLE
Change README for avoid misleading related to vendor/assets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Set to `true` to enable additional runtime error checking. Recommended in the `d
 
 **`config.assets.paths`**
 
-Add additional load paths to this Array. Rails includes `app/assets` and `vendor/assets` for you already. Plugins might want to add their custom paths to to this.
+Add additional load paths to this Array. Rails includes `app/assets` and `vendor/assets` ( `vendor/assets` support removed in Rails 4) for you already. Plugins might want to add their custom paths to to this.
 
 **`config.assets.version`**
 


### PR DESCRIPTION
https://github.com/rails/rails/pull/7968  from this ticket. Default design was already changed a years ago. Should change README as well.
