### PR TITLE
Increment the `env.version` with `asset_host` and `relative_url_root`

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -66,8 +66,16 @@ module Sprockets
 
       manifest_path = File.join(app.root, 'public', config.assets.prefix)
 
-      unless config.assets.version.blank?
-        app.assets.version += "-#{config.assets.version}"
+      # Configuration options that should invalidate
+      # the Sprockets cache when changed.
+      version_fragments = [
+        config.assets.version,
+        config.action_controller.relative_url_root,
+        config.action_controller.asset_host
+      ].compact.join('-')
+
+      if version_fragments.present?
+        app.assets.version += "-#{version_fragments}"
       end
 
       # Copy config.assets.paths to Sprockets

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -109,6 +109,18 @@ class TestRailtie < TestBoot
     assert_equal "test-v2", env.version
   end
 
+  def test_version_fragments
+    app.configure do
+      config.assets.version = 'v2'
+      config.action_controller.asset_host = 'http://some-cdn.com'
+      config.action_controller.relative_url_root = 'some-path'
+    end
+    app.initialize!
+
+    assert env = app.assets
+    assert_equal "test-v2-some-path-http://some-cdn.com", env.version
+  end
+
   def test_configure
     app.configure do
       config.assets.configure do |env|


### PR DESCRIPTION
Closes #69 

This way such configurations will affect the asset fingerprints and the environment cache, since they might affect the assets contents.

Let me know if there is any other configuration that should affect the fingerprinting/cache that should be on this list.
