### PR TITLE
Restore `config.assets.manifest` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### Master
 
+*   Restore `config.assets.manifest` option, which was removed in Rails 4.0.0.
+    This change does not affect existing behavior if the option is not set.
+
+     *Johnny Shields*
+
 *   Assets not in the precompile list can be checked for errors by setting
      `config.assets.raise_runtime_errors  = true` in any environment
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ config.assets.version = 'v2'
 
 Defaults to `/assets`. Changes the directory to compile assets to.
 
+**`config.assets.manifest`**
+
+Defines the full path to be used for the asset precompiler's manifest file. Defaults to using the `config.assets.prefix` directory within the public folder.
+
 **`config.assets.digest`**
 
 Link to undigest asset filenames. This option will eventually go away. Unless when `compile` is disabled.

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -50,6 +50,7 @@ module Sprockets
     config.assets._blocks    = []
     config.assets.paths      = []
     config.assets.prefix     = "/assets"
+    config.assets.manifest   = false
     config.assets.precompile = [LOOSE_APP_ASSETS, /(?:\/|\\|\A)application\.(css|js)$/]
     config.assets.version    = ""
     config.assets.debug      = false
@@ -64,7 +65,7 @@ module Sprockets
     config.after_initialize do |app|
       config = app.config
 
-      manifest_path = File.join(app.root, 'public', config.assets.prefix)
+      manifest_path = config.assets.manifest || File.join(app.root, 'public', config.assets.prefix)
 
       # Configuration options that should invalidate
       # the Sprockets cache when changed.

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -174,4 +174,13 @@ class TestRailtie < TestBoot
     assert_equal false, env.context_class.digest_assets
     assert_equal nil, env.context_class.config.asset_host
   end
+
+  def test_manifest_path
+    app.configure do
+      config.assets.manifest = Rails.root.join('config','foo')
+    end
+    app.initialize!
+
+    assert_match %r{config/foo/manifest-.*.json}, ActionView::Base.assets_manifest.path
+  end
 end


### PR DESCRIPTION
Restore `config.assets.manifest` option, which was removed in Rails 4.0.0 (see https://github.com/rails/rails/pull/7702.) This change does not affect existing behavior if the option is not set.

There is a long discussion of the reason for this in https://github.com/rails/sprockets-rails/issues/107.
