### PR TITLE
Instead of complaining, add the dependency automatically

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -21,14 +21,6 @@ module Sprockets
         Sprockets::Rails::Helper.raise_runtime_errors
       end
 
-      class DependencyError < StandardError
-        def initialize(path, dep)
-          msg = "Asset depends on '#{dep}' to generate properly but has not declared the dependency\n"
-          msg << "Please add: `//= depend_on_asset \"#{dep}\"` to '#{path}'"
-          super msg
-        end
-      end
-
       class AssetFilteredError < StandardError
         def initialize(source)
           msg = "Asset filtered out and will not be served: " <<
@@ -71,7 +63,7 @@ module Sprockets
 
       def compute_asset_path(path, options = {})
         # Check if we are inside Sprockets context before calling check_dependencies!.
-        check_dependencies!(path) if defined?(_dependency_assets)
+        check_dependencies!(path) if defined?(depend_on)
 
         if digest_path = asset_digest_path(path)
           path = digest_path if digest_assets
@@ -177,11 +169,10 @@ module Sprockets
       end
 
       protected
-        # Checks if the asset is included in the dependencies list.
+        # Ensures the asset is included in the dependencies list.
         def check_dependencies!(dep)
-          if raise_runtime_errors && !_dependency_assets.detect { |asset| asset.include?(dep) }
-            raise DependencyError.new(self.pathname, dep)
-          end
+          depend_on(dep)
+          depend_on_asset(dep)
         end
 
         # Raise errors when source does not exist or is not in the precompiled list

--- a/test/fixtures/url.css.erb
+++ b/test/fixtures/url.css.erb
@@ -1,2 +1,1 @@
-//= depend_on_asset "logo.png"
 p { background: url(<%= image_path "logo.png" %>); }

--- a/test/fixtures/url.js.erb
+++ b/test/fixtures/url.js.erb
@@ -1,2 +1,1 @@
-//= depend_on_asset "foo.js"
 var url = '<%= javascript_path :foo %>';

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -435,18 +435,13 @@ class ManifestHelperTest < NoHostHelperTest
   end
 end
 
-class ErrorsInHelpersTest < HelperTest
+class AutomaticDependenciesFromHelpersTest < HelperTest
 
-  def test_dependency_error
-    Sprockets::Rails::Helper.raise_runtime_errors = true
-    Sprockets::Rails::Helper.precompile           = [ lambda {|logical_path| true } ]
-    @view.assets_environment                      = @assets
+  def test_dependency_added
+    @view.assets_environment = @assets
 
-    assert_raises Sprockets::Rails::Helper::DependencyError do
-      @view.asset_path("error/dependency.js")
-    end
+    @view.asset_path("url.css")
 
-    Sprockets::Rails::Helper.raise_runtime_errors = false
-    @view.asset_path("error/dependency.js")
+    assert_equal ["logo.png", "url.css.erb"], @assets['url.css'].send(:dependency_paths).map {|d| File.basename(d.pathname) }.sort
   end
 end


### PR DESCRIPTION
It seems we can easily make #125 Just Work.

Experimentally, I've determined that:
- using `depend_on_asset` in a `.css.scss` file to match an `image-url` is sufficient to make the error go away, but is **not** sufficient to cause the generated CSS to be rebuilt when the image content changes
- with this, no `depend_on_asset` is required, and it Just Works.

Am I just being even more obtuse than usual? Is there some particular arrangement where this doesn't work, and we must insist that the author give us the information?

---

We need to use _both_ `depend_on` and `depend_on_asset`, because the latter (bugfully?) considers changes to the referenced asset's dependencies, but not the file itself (making it entirely useless for an image).

I'll follow up on that point with Sprockets, but given that we're currently locked very firmly on a particular version, and that it'll remain a safe no-op if `depend_on_asset` starts to do the job of `depend_on` too, it seems best for us to just call both -- at least for now.

---

Suggestions to avoid calling a Sprockets-protected method are welcome... though again, right now, we know we're breaching Sprockets intended public API. And I suspect that would apply to the current usage of `_dependency_assets`, too.

@rafaelfranca @schneems
