### PR TITLE
Version the gem's helpers; if they change, the cache must go

### DIFF
--- a/lib/sprockets/rails.rb
+++ b/lib/sprockets/rails.rb
@@ -1,3 +1,4 @@
+require 'sprockets/rails/version'
 if defined? Rails::Railtie
   require 'sprockets/railtie'
 end

--- a/lib/sprockets/rails/version.rb
+++ b/lib/sprockets/rails/version.rb
@@ -1,0 +1,5 @@
+module Sprockets
+  module Rails
+    VERSION = "2.1.1"
+  end
+end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -69,15 +69,13 @@ module Sprockets
 
       # Configuration options that should invalidate
       # the Sprockets cache when changed.
-      version_fragments = [
+      app.assets.version = [
+        app.assets.version,
         config.assets.version,
         config.action_controller.relative_url_root,
-        config.action_controller.asset_host
+        config.action_controller.asset_host,
+        Sprockets::Rails::VERSION,
       ].compact.join('-')
-
-      if version_fragments.present?
-        app.assets.version += "-#{version_fragments}"
-      end
 
       # Copy config.assets.paths to Sprockets
       config.assets.paths.each do |path|

--- a/sprockets-rails.gemspec
+++ b/sprockets-rails.gemspec
@@ -1,6 +1,9 @@
+$:.unshift File.expand_path("../lib", __FILE__)
+require "sprockets/rails/version"
+
 Gem::Specification.new do |s|
   s.name = "sprockets-rails"
-  s.version = "2.1.0"
+  s.version = Sprockets::Rails::VERSION
 
   s.homepage = "https://github.com/rails/sprockets-rails"
   s.summary  = "Sprockets Rails integration"

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -50,7 +50,7 @@ class TestRailtie < TestBoot
     assert_kind_of Sprockets::Environment, env
 
     assert_equal ROOT, env.root
-    assert_equal "test", env.version
+    assert_equal "test--#{Sprockets::Rails::VERSION}", env.version
     assert env.cache
     assert_equal [], env.paths
     assert_nil env.js_compressor
@@ -108,7 +108,7 @@ class TestRailtie < TestBoot
     app.initialize!
 
     assert env = app.assets
-    assert_equal "test-v2", env.version
+    assert_equal "test-v2-#{Sprockets::Rails::VERSION}", env.version
   end
 
   def test_version_fragments
@@ -120,7 +120,7 @@ class TestRailtie < TestBoot
     app.initialize!
 
     assert env = app.assets
-    assert_equal "test-v2-some-path-http://some-cdn.com", env.version
+    assert_equal "test-v2-some-path-http://some-cdn.com-#{Sprockets::Rails::VERSION}", env.version
   end
 
   def test_configure


### PR DESCRIPTION
Sprockets incorporates its own version into the digest, so any update will clear the cache; we should follow suit.
