### PR TITLE
Check precompile for the asset's logical_path

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -70,7 +70,7 @@ module Sprockets
       # Computes the full URL to a asset in the public directory. This
       # method checks for errors before returning path.
       def asset_path(source, options = {})
-        check_errors_for(source)
+        check_errors_for(source, options)
         path_to_asset(source, options)
       end
       alias :path_to_asset_with_errors :asset_path
@@ -124,7 +124,7 @@ module Sprockets
 
         if options["debug"] != false && request_debug_assets?
           sources.map { |source|
-            check_errors_for(source)
+            check_errors_for(source, :type => :javascript)
             if asset = lookup_asset_for_path(source, :type => :javascript)
               asset.to_a.map do |a|
                 super(path_to_javascript(a.logical_path, :debug => true), options)
@@ -146,7 +146,7 @@ module Sprockets
         options = sources.extract_options!.stringify_keys
         if options["debug"] != false && request_debug_assets?
           sources.map { |source|
-            check_errors_for(source)
+            check_errors_for(source, :type => :stylesheet)
             if asset = lookup_asset_for_path(source, :type => :stylesheet)
               asset.to_a.map do |a|
                 super(path_to_stylesheet(a.logical_path, :debug => true), options)
@@ -169,13 +169,13 @@ module Sprockets
         end
 
         # Raise errors when source does not exist or is not in the precompiled list
-        def check_errors_for(source)
+        def check_errors_for(source, options)
           source = source.to_s
           return source if !self.raise_runtime_errors || source.blank? || source =~ URI_REGEXP
-          asset = lookup_asset_for_path(source)
+          asset = lookup_asset_for_path(source, options)
 
-          if asset && asset_needs_precompile?(source, asset.pathname.to_s)
-            raise AssetFilteredError.new(source)
+          if asset && asset_needs_precompile?(asset.logical_path, asset.pathname.to_s)
+            raise AssetFilteredError.new(asset.logical_path)
           end
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -406,9 +406,25 @@ class ManifestHelperTest < NoHostHelperTest
       @view.javascript_include_tag(:foo)
     end
 
+    Sprockets::Rails::Helper.precompile = ['foo.js']
+
+    @view.asset_path("foo.js")
+    @view.asset_url("foo.js")
+    @view.javascript_include_tag("foo.js")
+    @view.javascript_include_tag("foo")
+    @view.javascript_include_tag(:foo)
+
     assert_raises(Sprockets::Rails::Helper::AssetFilteredError) do
-      @view.stylesheet_link_tag("foo.js")
+      @view.stylesheet_link_tag("foo")
     end
+
+    Sprockets::Rails::Helper.precompile = ['foo.css']
+
+    assert_raises(Sprockets::Rails::Helper::AssetFilteredError) do
+      @view.javascript_include_tag("foo")
+    end
+
+    @view.stylesheet_link_tag("foo")
 
     Sprockets::Rails::Helper.precompile = [ lambda {|logical_path| true } ]
 
@@ -417,7 +433,7 @@ class ManifestHelperTest < NoHostHelperTest
     @view.javascript_include_tag("foo.js")
     @view.javascript_include_tag("foo")
     @view.javascript_include_tag(:foo)
-    @view.stylesheet_link_tag("foo.js")
+    @view.stylesheet_link_tag("foo")
   end
 
   def test_asset_digest_path
@@ -434,8 +450,6 @@ end
 class AutomaticDependenciesFromHelpersTest < HelperTest
 
   def test_dependency_added
-    @view.assets_environment = @assets
-
     @view.asset_path("url.css")
 
     assert_equal ["logo.png", "url.css.erb"], @assets['url.css'].send(:dependency_paths).map {|d| File.basename(d.pathname) }.sort


### PR DESCRIPTION
.. not whatever source we were originally given, which may be missing an extension.

In doing so, we must also ensure that when we look up an asset from an extensionless name, we end up with the one we intended -- so `check_errors_for` should pass a `:type` through.

Fixes #128.
