### PR TITLE
Precompile configuration now lives in an initializer

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -24,8 +24,8 @@ module Sprockets
       class AssetFilteredError < StandardError
         def initialize(source)
           msg = "Asset filtered out and will not be served: " <<
-                "add `config.assets.precompile += %w( #{source} )` " <<
-                "to `config/application.rb` and restart your server"
+                "add `Rails.application.config.assets.precompile += %w( #{source} )` " <<
+                "to `config/initializers/assets.rb` and restart your server"
           super(msg)
         end
       end


### PR DESCRIPTION
Update the error message to match rails/rails#14689.

Even if the user doesn't currently have this initializer, they can safely create it with the supplied content, and all will be good.
