### PR TITLE
Fix uninitialized constant

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -4,6 +4,7 @@ require 'action_controller/railtie'
 require 'active_support/core_ext/module/remove_method'
 require 'sprockets'
 require 'sprockets/rails/helper'
+require 'sprockets/rails/version'
 
 module Rails
   class Application


### PR DESCRIPTION
With sprockets-rails 2.1.2 there is error: ruby-2.1.1/gems/sprockets-rails-2.1.2/lib/sprockets/railtie.rb:77:in `block in class:Railtie': uninitialized constant Sprockets::Rails::VERSION (NameError)

This require fixes the issue.
