### PR TITLE
Ensure supplied asset paths don't contain "/assets/"

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -30,6 +30,14 @@ module Sprockets
         end
       end
 
+      class AbsoluteAssetPathError < ArgumentError
+        def initialize(bad_path, good_path, prefix)
+          msg = "Asset names passed to helpers should not include the #{prefix.inspect} prefix. " <<
+                "Instead of #{bad_path.inspect}, use #{good_path.inspect}"
+          super(msg)
+        end
+      end
+
       include ActionView::Helpers::AssetUrlHelper
       include ActionView::Helpers::AssetTagHelper
 
@@ -168,14 +176,26 @@ module Sprockets
           depend_on_asset(dep)
         end
 
-        # Raise errors when source does not exist or is not in the precompiled list
+        # Raise errors when source is not in the precompiled list, or
+        # incorrectly contains the assets_prefix.
         def check_errors_for(source, options)
+          return unless self.raise_runtime_errors
+
           source = source.to_s
-          return source if !self.raise_runtime_errors || source.blank? || source =~ URI_REGEXP
+          return if source.blank? || source =~ URI_REGEXP
+
           asset = lookup_asset_for_path(source, options)
 
           if asset && asset_needs_precompile?(asset.logical_path, asset.pathname.to_s)
             raise AssetFilteredError.new(asset.logical_path)
+          end
+
+          full_prefix = File.join(self.assets_prefix || "/", '')
+          if !asset && source.start_with?(full_prefix)
+            short_path = source[full_prefix.size, source.size]
+            if lookup_asset_for_path(short_path, options)
+              raise AbsoluteAssetPathError.new(source, short_path, full_prefix)
+            end
           end
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -380,6 +380,22 @@ class ManifestHelperTest < NoHostHelperTest
     @view.javascript_include_tag("asset-does-not-exist-foo.js")
   end
 
+  def test_absolute_asset_path_error
+    Sprockets::Rails::Helper.raise_runtime_errors = true
+    @view.assets_environment = @assets
+
+    assert_equal "/assets/foo-#{@foo_js_digest}.js", @view.asset_path("foo.js")
+    assert_raises(Sprockets::Rails::Helper::AbsoluteAssetPathError) do
+      @view.asset_path("/assets/foo.js")
+    end
+
+    assert_equal "/unknown.js", @view.asset_path("unknown.js")
+    assert_equal "/assets/unknown.js", @view.asset_path("/assets/unknown.js")
+
+    Sprockets::Rails::Helper.raise_runtime_errors = false
+    assert_equal "/assets/foo.js", @view.asset_path("/assets/foo.js")
+  end
+
   def test_asset_not_precompiled_error
     Sprockets::Rails::Helper.raise_runtime_errors = true
     Sprockets::Rails::Helper.precompile           = [ lambda {|logical_path| false } ]


### PR DESCRIPTION
This is a somewhat common error, and an easy way to end up with missing digests in production.
