### PR TITLE
Ignore missing dependencies, instead of failing

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -166,6 +166,7 @@ module Sprockets
         def check_dependencies!(dep)
           depend_on(dep)
           depend_on_asset(dep)
+        rescue Sprockets::FileNotFound
         end
 
         # Raise errors when source does not exist or is not in the precompiled list

--- a/test/fixtures/error/missing.css.erb
+++ b/test/fixtures/error/missing.css.erb
@@ -1,0 +1,1 @@
+p { background: url(<%= image_path "does_not_exist.png" %>); }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -450,8 +450,11 @@ end
 class AutomaticDependenciesFromHelpersTest < HelperTest
 
   def test_dependency_added
-    @view.asset_path("url.css")
-
     assert_equal ["logo.png", "url.css.erb"], @assets['url.css'].send(:dependency_paths).map {|d| File.basename(d.pathname) }.sort
   end
+
+  def test_ignores_missing_dependencies
+    assert_equal ["missing.css.erb"], @assets['error/missing.css'].send(:dependency_paths).map {|d| File.basename(d.pathname) }.sort
+  end
+
 end


### PR DESCRIPTION
Arguably, Sprockets should be capable of depending on a non-existent filename, so it knows our content would change if it appeared.

But for now, carrying on silently is the best we can do.

(per @robin850 -- https://github.com/rails/sass-rails/pull/209#issuecomment-40924999)
