### PR TITLE
Show latest build status for the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ $ bundle install
 $ bundle exec rake test
 ```
 
-[![Build Status](https://secure.travis-ci.org/rails/sprockets-rails.png)](http://travis-ci.org/rails/sprockets-rails)
+[![Build Status](https://travis-ci.org/rails/sprockets-rails.svg?branch=master)](https://travis-ci.org/rails/sprockets-rails)
 
 
 ## Releases


### PR DESCRIPTION
Currently, the README shows the build status for the latest build regardless of the branch. This change only shows the build status for the latest build for the master branch.

If the current setup of reflecting the latest build for any branch is deliberate, I'm curious why that is. Thanks!
