### PR TITLE
Inconsistent public path in rake task and railtie

### DIFF
--- a/lib/sprockets/rails/task.rb
+++ b/lib/sprockets/rails/task.rb
@@ -24,7 +24,8 @@ module Sprockets
 
       def output
         if app
-          File.join(app.root, 'public', app.config.assets.prefix)
+          config = app.config
+          File.join(app.root, config.paths['public'].first, config.assets.prefix)
         else
           super
         end


### PR DESCRIPTION
I think we should use `config.paths['public'].first` in `output` method to make it consistent with `manifest_assets_path` in [sprockets-rails/lib/railtie.rb](https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/railtie.rb#L70)
