### PR TITLE
Should use config path tmp for cache path

### DIFF
--- a/lib/sprockets/rails/task.rb
+++ b/lib/sprockets/rails/task.rb
@@ -49,7 +49,7 @@ module Sprockets
 
       def cache_path
         if app
-          "#{app.config.root}/tmp/cache/assets"
+          "#{app.config.paths['tmp'].first}/cache/assets"
         else
           @cache_path
         end


### PR DESCRIPTION
We have option `config.paths['tmp']` in rails. Therefore i think we should make it can be editable
