### PR TITLE
Support Sprockets 3.x

### DIFF
--- a/sprockets-rails.gemspec
+++ b/sprockets-rails.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "lib/**/*.rb", "LICENSE"]
 
-  s.add_dependency "sprockets", "~> 2.8"
+  s.add_dependency "sprockets", [">= 2.8", "< 4.0"]
   s.add_dependency "actionpack", ">= 3.0"
   s.add_dependency "activesupport", ">= 3.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
Hey @rafaelfranca,

Heres my idea. We add support for Sprockets 3.x to Sprockets-Rails 2.x. Sprockets 3.x is intended to be api compatible with 2.x so it should work on both versions. This would allow people to start testing the Sprockets 3.x beta on Rails 4.1.x.

I still think we should release a Sprockets-Rails 3.x that would drop 2.x support and only use non-deprecated apis from 3.x.

wdyt?
