### PR TITLE
Fix version in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
     *Johnny Shields*
 
-### 2.3.0
+### 2.2.2
 
 *   Expose Rails.application.assets_manifest
 


### PR DESCRIPTION
The correct version is `2.2.2`, not `2.3.0`.
