### PR TITLE
Import append_assets_path initializer

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -40,7 +40,7 @@ module Rails
   class Engine < Railtie
     # Skip defining append_assets_path on Rails <= 4.2
     unless initializers.find { |init| init.name == :append_assets_path }
-      initializer :append_assets_path, group: :all do |app|
+      initializer :append_assets_path, :group => :all do |app|
         app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
         app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
         app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -41,9 +41,15 @@ module Rails
     # Skip defining append_assets_path on Rails <= 4.2
     unless initializers.find { |init| init.name == :append_assets_path }
       initializer :append_assets_path, :group => :all do |app|
-        app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
-        app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
-        app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)
+        if paths["app/assets"].respond_to?(:existent_directories)
+          app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
+          app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
+          app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)
+        else
+          app.config.assets.paths.unshift(*paths["vendor/assets"].paths.select { |d| File.directory?(d) })
+          app.config.assets.paths.unshift(*paths["lib/assets"].paths.select { |d| File.directory?(d) })
+          app.config.assets.paths.unshift(*paths["app/assets"].paths.select { |d| File.directory?(d) })
+        end
       end
     end
   end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -36,6 +36,17 @@ module Rails
     # Returns Sprockets::Manifest for app config.
     attr_accessor :assets_manifest
   end
+
+  class Engine < Railtie
+    # Skip defining append_assets_path on Rails <= 4.2
+    unless initializers.find { |init| init.name == :append_assets_path }
+      initializer :append_assets_path, group: :all do |app|
+        app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
+        app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
+        app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)
+      end
+    end
+  end
 end
 
 module Sprockets


### PR DESCRIPTION
Alright, @rafaelfranca

Heres the idea for moving the `append_assets_path` into this plugin.

Then in rails/master we could completely remove `config.assets` and this guy. This code would still cover people running Rails 4.2. And eventually we can remove the guard when we only need to support Rails 5.

Related discussion

* https://github.com/rails/rails/pull/18607