### PR TITLE
Always initialize assets environment in rake task

### DIFF
--- a/lib/sprockets/rails/task.rb
+++ b/lib/sprockets/rails/task.rb
@@ -16,7 +16,9 @@ module Sprockets
 
       def environment
         if app
-          app.assets
+          # Use initialized app.assets or force build an environment if
+          # config.assets.compile is disabled
+          app.assets || Sprockets::Railtie.build_environment(app)
         else
           super
         end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -69,7 +69,8 @@ module Sprockets
       Sprockets::Rails::Task.new(app)
     end
 
-    def build_environment(app, initialized: app.initialized?)
+    def build_environment(app, initialized = nil)
+      initialized = app.initialized? if initialized.nil?
       unless initialized
         ::Rails.logger.warn "Application uninitialized: Try calling YourApp::Application.initialize!"
       end
@@ -130,7 +131,7 @@ module Sprockets
       config = app.config
 
       if config.assets.compile
-        app.assets = self.build_environment(app, initialized: true)
+        app.assets = self.build_environment(app, true)
         app.routes.prepend do
           mount app.assets => config.assets.prefix
         end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -69,7 +69,11 @@ module Sprockets
       Sprockets::Rails::Task.new(app)
     end
 
-    def self.build_environment(app)
+    def build_environment(app, initialized: app.initialized?)
+      unless initialized
+        ::Rails.logger.warn "Application uninitialized: Try calling YourApp::Application.initialize!"
+      end
+
       config = app.config
       env = Sprockets::Environment.new(app.root.to_s)
 
@@ -126,7 +130,7 @@ module Sprockets
       config = app.config
 
       if config.assets.compile
-        app.assets = self.build_environment(app)
+        app.assets = self.build_environment(app, initialized: true)
         app.routes.prepend do
           mount app.assets => config.assets.prefix
         end

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -291,20 +291,21 @@ class TestRailtie < TestBoot
     app.initialize!
     app.load_tasks
 
-    digest_path = app.assets['foo.js'].digest_path
+    path = "#{app.assets_manifest.dir}/foo-4ef5541f349f7ed5a0d6b71f2fa4c82745ca106ae02f212aea5129726ac6f6ab.js"
+
     silence_stderr do
       Rake.application['assets:clobber'].execute
     end
-    refute File.exist?("#{app.assets_manifest.dir}/#{digest_path}")
+    refute File.exist?(path)
 
     silence_stderr do
       Rake.application['assets:precompile'].execute
     end
-    assert File.exist?("#{app.assets_manifest.dir}/#{digest_path}")
+    assert File.exist?(path)
 
     silence_stderr do
       Rake.application['assets:clobber'].execute
     end
-    refute File.exist?("#{app.assets_manifest.dir}/#{digest_path}")
+    refute File.exist?(path)
   end
 end

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -264,4 +264,15 @@ class TestRailtie < TestBoot
     assert_match %r{test_public/assets/manifest-.*\.json$}, manifest.path
     assert_match %r{test_public/assets$}, manifest.dir
   end
+
+  def test_load_tasks
+    app.initialize!
+
+    app.load_tasks
+
+    assert Rake.application['assets:environment']
+    assert Rake.application['assets:precompile']
+    assert Rake.application['assets:clean']
+    assert Rake.application['assets:clobber']
+  end
 end

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -308,4 +308,31 @@ class TestRailtie < TestBoot
     end
     refute File.exist?(path)
   end
+
+  def test_task_precompile_compile_false
+    app.configure do
+      config.assets.compile = false
+      config.assets.paths << FIXTURES_PATH
+      config.assets.precompile += ["foo.js"]
+    end
+    app.initialize!
+    app.load_tasks
+
+    path = "#{app.assets_manifest.dir}/foo-4ef5541f349f7ed5a0d6b71f2fa4c82745ca106ae02f212aea5129726ac6f6ab.js"
+
+    silence_stderr do
+      Rake.application['assets:clobber'].execute
+    end
+    refute File.exist?(path)
+
+    silence_stderr do
+      Rake.application['assets:precompile'].execute
+    end
+    assert File.exist?(path)
+
+    silence_stderr do
+      Rake.application['assets:clobber'].execute
+    end
+    refute File.exist?(path)
+  end
 end

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -335,4 +335,19 @@ class TestRailtie < TestBoot
     end
     refute File.exist?(path)
   end
+
+  def test_direct_build_environment_call
+    app.configure do
+      config.assets.paths << "javascripts"
+      config.assets.paths << "stylesheets"
+    end
+    app.initialize!
+
+    assert env = Sprockets::Railtie.build_environment(app)
+    assert_kind_of Sprockets::Environment, env
+
+    assert_equal ROOT, env.root
+    assert_equal ["#{ROOT}/javascripts", "#{ROOT}/stylesheets"],
+      env.paths.sort
+  end
 end


### PR DESCRIPTION
#220 causes a slight regression but brings up this weird issue again.

If `config.assets.compile = false` in `production.rb` than you can't even do `rake assets:precompile`.

This is a little work around to force the environment to build even in this case.

@rafaelfranca the environment weirdness between `rake assets:precompile` has always bugged me. Given 3.x can have backwards incompatible changes, have any idea for directions we can move into to make this more clear?

I really wish `rake assets:precompile` would work no matter what and always minified the assets even in RAILS_ENV=development. Would like to make it easier for people who compile assets in an isolate environment and upload them to a CDN. This sometimes happens locally on there machine and othertimes in production like environments that might not have a db.