### PR TITLE
Experimental SRI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ The following plugins provide some extras for the Sprockets Asset Pipeline.
 * `config.assets.manifest` (if used) must now include the manifest filename, e.g. `Rails.root.join('config/manifest.json')`. It cannot be a directory.
 * Two cleanup tasks. `rake assets:clean` is now a safe cleanup that only removes older assets that are no longer used. While `rake assets:clobber` nukes the entire `public/assets` directory and clears your filesystem cache. The clean task allows for rolling deploys that may still be linking to an old asset while the new assets are being built.
 
+## Experimental
+
+### [SRI](http://www.w3.org/TR/SRI/) support
+
+Sprockets 3.x adds experimental support for subresource integrity checks. The spec is still evolving and the API may change in backwards incompatible ways.
+
+``` ruby
+javascript_include_tag :application, integrity: true
+# => "<script src="/assets/application.js" integrity="ni:///sha-256;TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs?ct=application/javascript"></script>"
+```
+
 
 ## Contributing
 

--- a/test/fixtures/bar.js
+++ b/test/fixtures/bar.js
@@ -1,1 +1,2 @@
 //= require foo
+var Bar;


### PR DESCRIPTION
Sprockets 3.x builds in some plumbing for getting [SRI](http://www.w3.org/TR/SRI/) hashes. This next step exposes the API at the Rails asset tag helper level.

``` ruby
javascript_include_tag :application, integrity: true
# => "<script src="/assets/application.js" integrity="ni:///sha-256;TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs?ct=application/javascript"></script>"
```

* The `integrity` format is still a little in flux. The format is generated in Sprockets itself, so spec changes *may* require core changes but nothing at the view level. The `integrity` attribute itself seems pretty established.
* `integrity: true` only works on Sprockets assets, not on `public/` static ones. It'd be cool if at some point in the future, Rails bakes this in directly and provides an asset integrity hook similar to the current `compute_asset_path` hook.
* Base branch targets `master` which is currently released as 3.x beta gems. This isn't going into 2.x stable.

Eventually this maybe something we can enable by default for Rails apps with a global config

``` ruby
config.assets.sri = true
```

/cc @rafaelfranca @jeremy @mastahyeti @mikewest