### PR TITLE
Don't precompile assets without an extension

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -58,7 +58,8 @@ end
 module Sprockets
   class Railtie < ::Rails::Railtie
     LOOSE_APP_ASSETS = lambda do |filename, path|
-      path =~ /app\/assets/ && !%w(.js .css).include?(File.extname(filename))
+      extname = File.extname(filename)
+      !extname.empty? && path =~ /app\/assets/ && !%w(.js .css).include?(extname)
     end
 
     class OrderedOptions < ActiveSupport::OrderedOptions


### PR DESCRIPTION
Sprockets 2.x dies with anything without an extension, 
READMEs from vendored assets are the most frequent offenders.

Fixes https://github.com/sstephenson/sprockets/issues/347.

I know the issue has been closed but the fix is so easy and simple I felt it was worth retrying.