### PR TITLE
Add `app/assets` to the load path.

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -33,6 +33,7 @@ module Rails
       initializer :append_assets_path, :group => :all do |app|
         app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
         app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
+        app.config.assets.paths.unshift(*paths["app"].existent_directories.grep(/\/assets\z/))
         app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)
       end
     end


### PR DESCRIPTION
Now we can compile manifests located at `app/assets/manifest.js` or something like it.