### PR TITLE
Move assets route internal decoration.

### DIFF
--- a/lib/sprockets/rails/route_wrapper.rb
+++ b/lib/sprockets/rails/route_wrapper.rb
@@ -1,0 +1,19 @@
+module Sprockets
+  module Rails
+    module RouteWrapper
+      def self.included(klass)
+        klass.class_attribute(:assets_prefix)
+        klass.class_eval do
+          def assets_prefix
+            self.class.assets_prefix
+          end
+
+          def internal_with_sprockets?
+            internal_without_sprockets? || path =~ %r{\A#{assets_prefix}\z}
+          end
+          alias_method_chain :internal?, :sprockets
+        end
+      end
+    end
+  end
+end

--- a/lib/sprockets/rails/route_wrapper.rb
+++ b/lib/sprockets/rails/route_wrapper.rb
@@ -1,15 +1,19 @@
 module Sprockets
   module Rails
     module RouteWrapper
-      def self.included(klass)
-        klass.class_attribute(:assets_prefix)
-        klass.class_eval do
-          def assets_prefix
-            self.class.assets_prefix
-          end
 
+      def internal_assets_path?
+        path =~ %r{\A#{self.class.assets_prefix}\z}
+      end
+
+      def internal?
+        super || internal_assets_path?
+      end
+
+      def self.included(klass)
+        klass.class_eval do
           def internal_with_sprockets?
-            internal_without_sprockets? || path =~ %r{\A#{assets_prefix}\z}
+            internal_without_sprockets? || internal_assets_path?
           end
           alias_method_chain :internal?, :sprockets
         end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -6,6 +6,7 @@ require 'active_support/core_ext/numeric/bytes'
 require 'sprockets'
 require 'sprockets/rails/context'
 require 'sprockets/rails/helper'
+require 'sprockets/rails/route_wrapper'
 require 'sprockets/rails/version'
 
 module Rails
@@ -145,6 +146,12 @@ module Sprockets
         end
       end
       app.assets_manifest = build_manifest(app)
+
+      ActionDispatch::Routing::RouteWrapper.class_eval do
+        include Sprockets::Rails::RouteWrapper
+
+        self.assets_prefix = config.assets.prefix
+      end
 
       ActiveSupport.on_load(:action_view) do
         include Sprockets::Rails::Helper

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -148,7 +148,13 @@ module Sprockets
       app.assets_manifest = build_manifest(app)
 
       ActionDispatch::Routing::RouteWrapper.class_eval do
-        include Sprockets::Rails::RouteWrapper
+        class_attribute :assets_prefix
+
+        if defined?(prepend) && ::Rails.version >= '4'
+          prepend Sprockets::Rails::RouteWrapper
+        else
+          include Sprockets::Rails::RouteWrapper
+        end
 
         self.assets_prefix = config.assets.prefix
       end


### PR DESCRIPTION
We can't depend on assets_prefix outside sprockets.

With this, we can create a rails --api without sprockets and `rake routes` wont fail.

After this is merged, we need to patch Rails. I will send a PR there too.

review @spastorino @rafaelfranca 
@zzak paired with me (he did most of the code :smiley_cat:)