### PR TITLE
adding "nodigest" task to add non digest assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Only removes old assets (keeps the most recent 3 copies) from `public/assets`. U
 
 Nuke `public/assets`.
 
-**`rake 'assets:generate_nondigests[app_sdk.js, app_sdk.css]''`**
+**`rake 'assets:generate_nondigests[app_sdk.js app_sdk.css]''`**
 
 Will generate non-digest files of the files passed in the parameters of the task (`app_sdk.js` and `app_sdk.css` in the example above). Useful if you need some of your assets to be available for developers outside of your application (Javascript SDK for example).
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Only removes old assets (keeps the most recent 3 copies) from `public/assets`. U
 
 Nuke `public/assets`.
 
+**`rake 'assets:generate_nondigests[app_sdk.js, app_sdk.css]''`**
+
+Will generate non-digest files of the files passed in the parameters of the task (`app_sdk.js` and `app_sdk.css` in the example above). Useful if you need some of your assets to be available for developers outside of your application (Javascript SDK for example).
+
+Remember that it's your responsibility to deal with cache expiration for those assets.
+
 #### Customize
 
 If the basic tasks don't do all that you need, it's straight forward to redefine them and replace them with something more specific to your app.

--- a/lib/sprockets/rails/task.rb
+++ b/lib/sprockets/rails/task.rb
@@ -83,9 +83,10 @@ module Sprockets
           end
 
           desc "Compile non-digest files"
-          task :generate_nondigest => :environment do |t, args|
-            files = args.extras
-            raise MissingParamsError.new("You must pass the files you want to generate nondigests (e.g. rake 'assets:generate_nondigests[file1.js, file2.js]')") if files.empty?
+          task :generate_nondigest, [:files_list] => :environment do |t, args|
+            raise MissingParamsError.new("You must pass the files you want to generate nondigests (e.g. rake assets:generate_nondigests['file1.js, file2.js'])") if args.files_list.nil?
+
+            files = args.files_list.split(' ')
 
             with_logger do
               generate_nondigests(files)

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -159,7 +159,7 @@ class TestTask < Minitest::Test
     assert File.exist?("#{@dir}/#{digest2_path}")
     refute File.exist?("#{@dir}/#{asset2_name}")
 
-    @rake['assets:generate_nondigest'].invoke(asset1_name, asset2_name)
+    @rake['assets:generate_nondigest'].invoke("#{asset1_name} #{asset2_name}")
 
     assert @environment_ran
     assert File.exist?("#{@dir}/#{digest1_path}"), "digest file 1 not found"

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -25,7 +25,7 @@ class TestTask < Minitest::Test
     Sprockets::Rails::Task.new do |t|
       t.environment = @assets
       t.manifest    = @manifest
-      t.assets      = ['foo.js', 'foo-modified.js']
+      t.assets      = ['foo.js', 'foo-modified.js', 'file1.js', 'file2.js']
       t.log_level   = :fatal
     end
 
@@ -138,5 +138,39 @@ class TestTask < Minitest::Test
     refute File.exist?("#{@dir}/#{old_digest_path}")
   ensure
     FileUtils.rm(new_path) if new_path
+  end
+
+  def test_generate_nondigests
+    assert !@environment_ran
+    asset1_name = "file1.js"
+    asset2_name = "file2.js"
+
+    digest1_path = @assets[asset1_name].digest_path
+    digest2_path = @assets[asset2_name].digest_path
+
+    @rake['assets:precompile'].invoke
+    assert @environment_ran
+
+    setup
+
+    assert !@environment_ran
+    assert File.exist?("#{@dir}/#{digest1_path}")
+    refute File.exist?("#{@dir}/#{asset1_name}")
+    assert File.exist?("#{@dir}/#{digest2_path}")
+    refute File.exist?("#{@dir}/#{asset2_name}")
+
+    @rake['assets:generate_nondigest'].invoke(asset1_name, asset2_name)
+
+    assert @environment_ran
+    assert File.exist?("#{@dir}/#{digest1_path}"), "digest file 1 not found"
+    assert File.exist?("#{@dir}/#{asset1_name}"), "nondigest file 1 not found"
+    assert File.exist?("#{@dir}/#{digest2_path}"), "digest file 2 not found"
+    assert File.exist?("#{@dir}/#{asset2_name}"), "nondigest file 2 not found"
+  end
+
+  def test_generate_nondigests_with_no_params
+    assert_raises Sprockets::Rails::Task::MissingParamsError do
+      @rake['assets:generate_nondigest'].invoke
+    end
   end
 end


### PR DESCRIPTION
## Problem

This gem does not generate non-digest files anymore.

A lot of apps still need the non-digest because some of their assets belongs to an SDK that they need to serve it outside of their application (e.g. like what Shopify [does](https://docs.shopify.com/embedded-app-sdk/initialization)). For that they need to have a constant URI for their assets.

There's  alternative like the [non-stupid-digest-assets](https://github.com/alexspeller/non-stupid-digest-assets) but I feel like this should be built-in as it's a more common pattern.
## Solution

Just copy existing files without the digest part of the name.
## Limitation

As we are not recompiling the file, any external file reference (image references) will still contain digested references. This is not a problem as the use case for this feature is to use the asset file as part of a SDK to be served to other developers, so references to digested files are OK.
## But, but... what about cache expiration?

That's a different problem for the developer to solve per asset file. The idea behind this is to enable the developer to generate a few non-digested files, not to serve the entire application assets.

As this not rake task is not run by default during `assets:precompile` the cache issue is another problem. This is an explicit action for a common and punctual problem.

cc @rafaelfranca @arthurnn for discussion
Related: #49 
