### PR TITLE
Prevent alias logical paths passed to asset_path

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -15,6 +15,15 @@ module Sprockets
         end
       end
 
+      class AssetAliasUsed < StandardError
+        def initialize(actual, expected)
+          msg = "Asset was linked to from an alias rather than its exact path. " +
+                "Alias resolving may not be available in production.\n" +
+                "Use #{expected.inspect} instead of #{actual.inspect}"
+          super(msg)
+        end
+      end
+
       include ActionView::Helpers::AssetUrlHelper
       include ActionView::Helpers::AssetTagHelper
 
@@ -80,6 +89,10 @@ module Sprockets
         if environment = assets_environment
           if asset = environment[path]
             unless options[:debug]
+              if path != asset.logical_path
+                raise AssetAliasUsed.new(path, asset.logical_path)
+              end
+
               if !precompiled_assets.include?(asset)
                 raise AssetNotPrecompiled.new(asset.logical_path)
               end

--- a/test/fixtures/bundle/index.js
+++ b/test/fixtures/bundle/index.js
@@ -1,0 +1,1 @@
+var jQuery;

--- a/test/fixtures/jquery/bower.json
+++ b/test/fixtures/jquery/bower.json
@@ -1,0 +1,4 @@
+{
+  "name": "jquery",
+  "main": "./jquery.js"
+}

--- a/test/fixtures/jquery/jquery.js
+++ b/test/fixtures/jquery/jquery.js
@@ -1,0 +1,1 @@
+var jQuery;

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -664,6 +664,26 @@ class AssetUrlHelperLinksTarget < HelperTest
     end
   end
 
+  def test_asset_path_with_index_requires_exact_logical_path
+    @view.assets_precompile = ["bundle.js"]
+
+    assert @view.asset_path("bundle.js")
+
+    assert_raises(Sprockets::Rails::Helper::AssetAliasUsed) do
+      assert @view.asset_path("bundle/index.js")
+    end
+  end
+
+  def test_asset_path_with_bower_requires_exact_logical_path
+    @view.assets_precompile = ["jquery/jquery.js"]
+
+    assert @view.asset_path("jquery/jquery.js")
+
+    assert_raises(Sprockets::Rails::Helper::AssetAliasUsed) do
+      assert @view.asset_path("jquery.js")
+    end
+  end
+
   def test_links_image_target
     assert_match "logo.png", @assets['url.css'].links.to_a[0]
   end


### PR DESCRIPTION
Theres a few other edge cases that will slip by the `AssetNotPrecompiled` check that are both issues today on 2.x and 3.x.

* `index` assets can **only** be referenced by their shorthand alias and not by the full path
* bower paths must be referenced by their full path and never there shorthand

The index case is annoying and I'm looking to address it in https://github.com/rails/sprockets/pull/36.

Though, I think this check is probably a good idea no matter what happens in sprockets core.

We basically assert that the input `path` which would be passed directly to `manifest.assets` in production matches the `logical_path` as it would be written out to disk.

The check only affects AV helpers, nothing within asset generation within sprockets.

/cc @arthurnn @rafaelfranca @matthewd 