### PR TITLE
Add support for Sprockets 4.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ gemfile:
   - gemfiles/Gemfile.rails-4.1.x
   - gemfiles/Gemfile.rails-4.2.x
   - gemfiles/Gemfile.rails-5.0.x
+  - gemfiles/Gemfile.rails-5.0.x.sprockets-4.x
 
 matrix:
   exclude:
@@ -28,6 +29,12 @@ matrix:
     - gemfile: gemfiles/Gemfile.rails-5.0.x
       rvm: 2.0.0
     - gemfile: gemfiles/Gemfile.rails-5.0.x
+      rvm: 2.1
+    - gemfile: gemfiles/Gemfile.rails-5.0.x.sprockets-4.x
+      rvm: 1.9.3
+    - gemfile: gemfiles/Gemfile.rails-5.0.x.sprockets-4.x
+      rvm: 2.0.0
+    - gemfile: gemfiles/Gemfile.rails-5.0.x.sprockets-4.x
       rvm: 2.1
 
 notifications:

--- a/gemfiles/Gemfile.rails-5.0.x.sprockets-4.x
+++ b/gemfiles/Gemfile.rails-5.0.x.sprockets-4.x
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+gemspec :path => ".."
+
+gem "actionpack", :github => "rails/rails", :branch => "master"
+gem "railties", :github => "rails/rails", :branch => "master"
+gem "sprockets", :github => "rails/sprockets", :branch => "4.x"

--- a/lib/sprockets/rails/context.rb
+++ b/lib/sprockets/rails/context.rb
@@ -17,7 +17,7 @@ module Sprockets
         @dependencies << 'actioncontroller-asset-url-config'
 
         begin
-          asset_uri = resolve(path, compat: false)
+          asset_uri = resolve(path)
         rescue FileNotFound
           # TODO: eh, we should be able to use a form of locate that returns
           # nil instead of raising an exception.
@@ -39,5 +39,10 @@ module Sprockets
     config = env.context_class.config
     [config.relative_url_root,
     (config.asset_host unless config.asset_host.respond_to?(:call))]
+  end
+
+  # fallback to the default pipeline when using Sprockets 3.x
+  unless config[:pipelines].include? :debug
+    register_pipeline :debug, config[:pipelines][:default]
   end
 end

--- a/lib/sprockets/rails/utils.rb
+++ b/lib/sprockets/rails/utils.rb
@@ -1,0 +1,11 @@
+require 'sprockets'
+
+module Sprockets
+  module Rails
+    module Utils
+      def using_sprockets4?
+        Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new('4.0.0')
+      end
+    end
+  end
+end

--- a/lib/sprockets/rails/version.rb
+++ b/lib/sprockets/rails/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module Rails
-    VERSION = "3.0.0.beta1"
+    VERSION = "3.0.0"
   end
 end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -43,6 +43,8 @@ end
 
 module Sprockets
   class Railtie < ::Rails::Railtie
+    include Sprockets::Rails::Utils
+
     LOOSE_APP_ASSETS = lambda do |logical_path, filename|
         filename.start_with?(::Rails.root.join("app/assets").to_s) &&
         !%w(.js .css).include?(File.extname(logical_path))
@@ -59,7 +61,11 @@ module Sprockets
     config.assets.paths       = []
     config.assets.prefix      = "/assets"
     config.assets.manifest    = nil
-    config.assets.precompile  = [LOOSE_APP_ASSETS, /(?:\/|\\|\A)application\.(css|js)$/]
+    if using_sprockets4?
+      config.assets.precompile  = %w( manifest.js )
+    else
+      config.assets.precompile  = [LOOSE_APP_ASSETS, /(?:\/|\\|\A)application\.(css|js)$/]
+    end
     config.assets.version     = ""
     config.assets.debug       = false
     config.assets.compile     = true

--- a/sprockets-rails.gemspec
+++ b/sprockets-rails.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.files = Dir["README.md", "lib/**/*.rb", "LICENSE"]
 
   s.required_ruby_version = '>= 1.9.3'
-  
-  s.add_dependency "sprockets", ">= 3.0.0", "< 4.0"
+
+  s.add_dependency "sprockets", ">= 3.0.0"
   s.add_dependency "actionpack", ">= 4.0"
   s.add_dependency "activesupport", ">= 4.0"
   s.add_development_dependency "railties", ">= 4.0"

--- a/test/fixtures/manifest.js
+++ b/test/fixtures/manifest.js
@@ -1,0 +1,9 @@
+// manifest.js
+//= link foo.css
+//= link foo.js
+//= link bar.css
+//= link bar.js
+//= link file1.css
+//= link file1.js
+//= link file2.css
+//= link file2.js

--- a/test/fixtures/not_precompiled.css
+++ b/test/fixtures/not_precompiled.css
@@ -1,0 +1,1 @@
+.not-precompiled {}

--- a/test/fixtures/not_precompiled.js
+++ b/test/fixtures/not_precompiled.js
@@ -1,0 +1,1 @@
+var not_precompiled;

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -24,10 +24,7 @@ class HelperTest < ActionView::TestCase
     @view.assets_environment = @assets
     @view.assets_manifest    = @manifest
     @view.assets_prefix      = "/assets"
-    @view.assets_precompile  = %w(
-      foo.css foo.js bar.css bar.js
-      file1.css file1.js file2.css file2.js
-    )
+    @view.assets_precompile  = %w( manifest.js )
     @view.request = ActionDispatch::Request.new({
       "rack.url_scheme" => "https"
     })
@@ -35,30 +32,46 @@ class HelperTest < ActionView::TestCase
     @assets.context_class.assets_prefix = @view.assets_prefix
     @assets.context_class.config        = @view.config
 
-    @foo_js_digest  = @assets['foo.js'].digest
-    @foo_css_digest = @assets['foo.css'].digest
-    @bar_js_digest  = @assets['bar.js'].digest
-    @bar_css_digest = @assets['bar.css'].digest
-    @logo_digest    = @assets['logo.png'].digest
+    @foo_js_digest  = @assets['foo.js'].etag
+    @foo_css_digest = @assets['foo.css'].etag
+    @bar_js_digest  = @assets['bar.js'].etag
+    @bar_css_digest = @assets['bar.css'].etag
+    @logo_digest    = @assets['logo.png'].etag
 
-    @foo_self_js_digest   = @assets['foo.self.js'].digest
-    @foo_self_css_digest  = @assets['foo.self.css'].digest
-    @bar_self_js_digest   = @assets['bar.self.js'].digest
-    @bar_self_css_digest  = @assets['bar.self.css'].digest
+    @foo_self_js_digest   = @assets['foo.self.js'].etag
+    @foo_self_css_digest  = @assets['foo.self.css'].etag
+    @bar_self_js_digest   = @assets['bar.self.js'].etag
+    @bar_self_css_digest  = @assets['bar.self.css'].etag
 
-    @dependency_js_digest  = @assets['dependency.js'].digest
-    @dependency_css_digest = @assets['dependency.css'].digest
-    @file1_js_digest       = @assets['file1.js'].digest
-    @file1_css_digest      = @assets['file1.css'].digest
-    @file2_js_digest       = @assets['file2.js'].digest
-    @file2_css_digest      = @assets['file2.css'].digest
+    @foo_debug_js_digest   = @assets['foo.debug.js'].etag
+    @foo_debug_css_digest  = @assets['foo.debug.css'].etag
+    @bar_debug_js_digest   = @assets['bar.debug.js'].etag
+    @bar_debug_css_digest  = @assets['bar.debug.css'].etag
 
-    @dependency_self_js_digest  = @assets['dependency.self.js'].digest
-    @dependency_self_css_digest = @assets['dependency.self.css'].digest
-    @file1_self_js_digest       = @assets['file1.self.js'].digest
-    @file1_self_css_digest      = @assets['file1.self.css'].digest
-    @file2_self_js_digest       = @assets['file2.self.js'].digest
-    @file2_self_css_digest      = @assets['file2.self.css'].digest
+    @dependency_js_digest  = @assets['dependency.js'].etag
+    @dependency_css_digest = @assets['dependency.css'].etag
+    @file1_js_digest       = @assets['file1.js'].etag
+    @file1_css_digest      = @assets['file1.css'].etag
+    @file2_js_digest       = @assets['file2.js'].etag
+    @file2_css_digest      = @assets['file2.css'].etag
+
+    @dependency_self_js_digest  = @assets['dependency.self.js'].etag
+    @dependency_self_css_digest = @assets['dependency.self.css'].etag
+    @file1_self_js_digest       = @assets['file1.self.js'].etag
+    @file1_self_css_digest      = @assets['file1.self.css'].etag
+    @file2_self_js_digest       = @assets['file2.self.js'].etag
+    @file2_self_css_digest      = @assets['file2.self.css'].etag
+
+    @dependency_debug_js_digest  = @assets['dependency.debug.js'].etag
+    @dependency_debug_css_digest = @assets['dependency.debug.css'].etag
+    @file1_debug_js_digest       = @assets['file1.debug.js'].etag
+    @file1_debug_css_digest      = @assets['file1.debug.css'].etag
+    @file2_debug_js_digest       = @assets['file2.debug.js'].etag
+    @file2_debug_css_digest      = @assets['file2.debug.css'].etag
+  end
+
+  def using_sprockets4?
+    Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new('4.0.0')
   end
 
   def test_truth
@@ -376,14 +389,14 @@ class DigestHelperTest < NoHostHelperTest
     assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js"></script>),
       @view.javascript_include_tag("foo", integrity: nil)
 
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha-256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
       @view.javascript_include_tag("foo", integrity: true)
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha-256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
       @view.javascript_include_tag("foo.js", integrity: true)
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha-256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
       @view.javascript_include_tag(:foo, integrity: true)
 
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha-256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>\n<script src="/assets/bar-#{@bar_js_digest}.js" integrity="sha-256-g0JYFeYSYGXe376R0JrRzS6CpYpC1HiqtwBsVt/XAWU="></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>\n<script src="/assets/bar-#{@bar_js_digest}.js" integrity="sha256-g0JYFeYSYGXe376R0JrRzS6CpYpC1HiqtwBsVt/XAWU="></script>),
       @view.javascript_include_tag(:foo, :bar, integrity: true)
   end
 
@@ -395,14 +408,14 @@ class DigestHelperTest < NoHostHelperTest
     assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag("foo", integrity: nil)
 
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha-256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
       @view.stylesheet_link_tag("foo", integrity: true)
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha-256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
       @view.stylesheet_link_tag("foo.css", integrity: true)
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha-256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
       @view.stylesheet_link_tag(:foo, integrity: true)
 
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha-256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />\n<link href="/assets/bar-#{@bar_css_digest}.css" media="screen" rel="stylesheet" integrity="sha-256-Vd370+VAW4D96CVpZcjFLXyeHoagI0VHwofmzRXetuE=" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />\n<link href="/assets/bar-#{@bar_css_digest}.css" media="screen" rel="stylesheet" integrity="sha256-Vd370+VAW4D96CVpZcjFLXyeHoagI0VHwofmzRXetuE=" />),
       @view.stylesheet_link_tag(:foo, :bar, integrity: true)
   end
 
@@ -440,35 +453,65 @@ class DebugHelperTest < NoHostHelperTest
   def test_javascript_include_tag
     super
 
-    assert_dom_equal %(<script src="/assets/foo.self.js?body=1"></script>),
-      @view.javascript_include_tag(:foo)
-    assert_dom_equal %(<script src="/assets/foo.self.js?body=1"></script>\n<script src="/assets/bar.self.js?body=1"></script>),
-      @view.javascript_include_tag(:bar)
-    assert_dom_equal %(<script src="/assets/dependency.self.js?body=1"></script>\n<script src="/assets/file1.self.js?body=1"></script>\n<script src="/assets/file2.self.js?body=1"></script>),
-      @view.javascript_include_tag(:file1, :file2)
+    if using_sprockets4?
+      assert_dom_equal %(<script src="/assets/foo.debug.js"></script>),
+        @view.javascript_include_tag(:foo)
+      assert_dom_equal %(<script src="/assets/bar.debug.js"></script>),
+        @view.javascript_include_tag(:bar)
+      assert_dom_equal %(<script src="/assets/file1.debug.js"></script>\n<script src="/assets/file2.debug.js"></script>),
+        @view.javascript_include_tag(:file1, :file2)
 
-    assert_servable_asset_url "/assets/foo.self.js?body=1"
-    assert_servable_asset_url "/assets/bar.self.js?body=1"
-    assert_servable_asset_url "/assets/dependency.self.js?body=1"
-    assert_servable_asset_url "/assets/file1.self.js?body=1"
-    assert_servable_asset_url "/assets/file2.self.js?body=1"
+      assert_servable_asset_url "/assets/foo.debug.js"
+      assert_servable_asset_url "/assets/bar.debug.js"
+      assert_servable_asset_url "/assets/dependency.debug.js"
+      assert_servable_asset_url "/assets/file1.debug.js"
+      assert_servable_asset_url "/assets/file2.debug.js"
+    else
+      assert_dom_equal %(<script src="/assets/foo.self.js?body=1"></script>),
+        @view.javascript_include_tag(:foo)
+      assert_dom_equal %(<script src="/assets/foo.self.js?body=1"></script>\n<script src="/assets/bar.self.js?body=1"></script>),
+        @view.javascript_include_tag(:bar)
+      assert_dom_equal %(<script src="/assets/dependency.self.js?body=1"></script>\n<script src="/assets/file1.self.js?body=1"></script>\n<script src="/assets/file2.self.js?body=1"></script>),
+        @view.javascript_include_tag(:file1, :file2)
+
+      assert_servable_asset_url "/assets/foo.self.js?body=1"
+      assert_servable_asset_url "/assets/bar.self.js?body=1"
+      assert_servable_asset_url "/assets/dependency.self.js?body=1"
+      assert_servable_asset_url "/assets/file1.self.js?body=1"
+      assert_servable_asset_url "/assets/file2.self.js?body=1"
+    end
   end
 
   def test_stylesheet_link_tag
     super
 
-    assert_dom_equal %(<link href="/assets/foo.self.css?body=1" media="screen" rel="stylesheet" />),
-      @view.stylesheet_link_tag(:foo)
-    assert_dom_equal %(<link href="/assets/foo.self.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/bar.self.css?body=1" media="screen" rel="stylesheet" />),
-      @view.stylesheet_link_tag(:bar)
-    assert_dom_equal %(<link href="/assets/dependency.self.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file1.self.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file2.self.css?body=1" media="screen" rel="stylesheet" />),
-      @view.stylesheet_link_tag(:file1, :file2)
+    if using_sprockets4?
+      assert_dom_equal %(<link href="/assets/foo.debug.css" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:foo)
+      assert_dom_equal %(<link href="/assets/bar.debug.css" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:bar)
+      assert_dom_equal %(<link href="/assets/file1.debug.css" media="screen" rel="stylesheet" />\n<link href="/assets/file2.debug.css" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:file1, :file2)
 
-    assert_servable_asset_url "/assets/foo.self.css?body=1"
-    assert_servable_asset_url "/assets/bar.self.css?body=1"
-    assert_servable_asset_url "/assets/dependency.self.css?body=1"
-    assert_servable_asset_url "/assets/file1.self.css?body=1"
-    assert_servable_asset_url "/assets/file2.self.css?body=1"
+      assert_servable_asset_url "/assets/foo.self.css"
+      assert_servable_asset_url "/assets/bar.self.css"
+      assert_servable_asset_url "/assets/dependency.self.css"
+      assert_servable_asset_url "/assets/file1.self.css"
+      assert_servable_asset_url "/assets/file2.self.css"
+    else
+      assert_dom_equal %(<link href="/assets/foo.self.css?body=1" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:foo)
+      assert_dom_equal %(<link href="/assets/foo.self.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/bar.self.css?body=1" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:bar)
+      assert_dom_equal %(<link href="/assets/dependency.self.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file1.self.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file2.self.css?body=1" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:file1, :file2)
+
+      assert_servable_asset_url "/assets/foo.self.css?body=1"
+      assert_servable_asset_url "/assets/bar.self.css?body=1"
+      assert_servable_asset_url "/assets/dependency.self.css?body=1"
+      assert_servable_asset_url "/assets/file1.self.css?body=1"
+      assert_servable_asset_url "/assets/file2.self.css?body=1"
+    end
   end
 
   def test_javascript_path
@@ -497,35 +540,65 @@ class DebugDigestHelperTest < NoHostHelperTest
   def test_javascript_include_tag
     super
 
-    assert_dom_equal %(<script src="/assets/foo.self-#{@foo_self_js_digest}.js?body=1"></script>),
-      @view.javascript_include_tag(:foo)
-    assert_dom_equal %(<script src="/assets/foo.self-#{@foo_self_js_digest}.js?body=1"></script>\n<script src="/assets/bar.self-#{@bar_self_js_digest}.js?body=1"></script>),
-      @view.javascript_include_tag(:bar)
-    assert_dom_equal %(<script src="/assets/dependency.self-#{@dependency_self_js_digest}.js?body=1"></script>\n<script src="/assets/file1.self-#{@file1_self_js_digest}.js?body=1"></script>\n<script src="/assets/file2.self-#{@file1_self_js_digest}.js?body=1"></script>),
-      @view.javascript_include_tag(:file1, :file2)
+    if using_sprockets4?
+      assert_dom_equal %(<script src="/assets/foo.debug-#{@foo_debug_js_digest}.js"></script>),
+        @view.javascript_include_tag(:foo)
+      assert_dom_equal %(<script src="/assets/bar.debug-#{@bar_debug_js_digest}.js"></script>),
+        @view.javascript_include_tag(:bar)
+      assert_dom_equal %(<script src="/assets/file1.debug-#{@file1_debug_js_digest}.js"></script>\n<script src="/assets/file2.debug-#{@file2_debug_js_digest}.js"></script>),
+        @view.javascript_include_tag(:file1, :file2)
 
-    assert_servable_asset_url "/assets/foo.self-#{@foo_self_js_digest}.js?body=1"
-    assert_servable_asset_url "/assets/bar.self-#{@bar_self_js_digest}.js?body=1"
-    assert_servable_asset_url "/assets/dependency.self-#{@dependency_self_js_digest}.js?body=1"
-    assert_servable_asset_url "/assets/file1.self-#{@file1_self_js_digest}.js?body=1"
-    assert_servable_asset_url "/assets/file2.self-#{@file2_self_js_digest}.js?body=1"
+      assert_servable_asset_url "/assets/foo.debug-#{@foo_debug_js_digest}.js"
+      assert_servable_asset_url "/assets/bar.debug-#{@bar_debug_js_digest}.js"
+      assert_servable_asset_url "/assets/dependency.debug-#{@dependency_debug_js_digest}.js"
+      assert_servable_asset_url "/assets/file1.debug-#{@file1_debug_js_digest}.js"
+      assert_servable_asset_url "/assets/file2.debug-#{@file2_debug_js_digest}.js"
+    else
+      assert_dom_equal %(<script src="/assets/foo.self-#{@foo_self_js_digest}.js?body=1"></script>),
+        @view.javascript_include_tag(:foo)
+      assert_dom_equal %(<script src="/assets/foo.self-#{@foo_self_js_digest}.js?body=1"></script>\n<script src="/assets/bar.self-#{@bar_self_js_digest}.js?body=1"></script>),
+        @view.javascript_include_tag(:bar)
+      assert_dom_equal %(<script src="/assets/dependency.self-#{@dependency_self_js_digest}.js?body=1"></script>\n<script src="/assets/file1.self-#{@file1_self_js_digest}.js?body=1"></script>\n<script src="/assets/file2.self-#{@file1_self_js_digest}.js?body=1"></script>),
+        @view.javascript_include_tag(:file1, :file2)
+
+      assert_servable_asset_url "/assets/foo.self-#{@foo_self_js_digest}.js?body=1"
+      assert_servable_asset_url "/assets/bar.self-#{@bar_self_js_digest}.js?body=1"
+      assert_servable_asset_url "/assets/dependency.self-#{@dependency_self_js_digest}.js?body=1"
+      assert_servable_asset_url "/assets/file1.self-#{@file1_self_js_digest}.js?body=1"
+      assert_servable_asset_url "/assets/file2.self-#{@file2_self_js_digest}.js?body=1"
+    end
   end
 
   def test_stylesheet_link_tag
     super
 
-    assert_dom_equal %(<link href="/assets/foo.self-#{@foo_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
-      @view.stylesheet_link_tag(:foo)
-    assert_dom_equal %(<link href="/assets/foo.self-#{@foo_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/bar.self-#{@bar_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
-      @view.stylesheet_link_tag(:bar)
-    assert_dom_equal %(<link href="/assets/dependency.self-#{@dependency_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file1.self-#{@file1_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file2.self-#{@file2_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
-      @view.stylesheet_link_tag(:file1, :file2)
+    if using_sprockets4?
+      assert_dom_equal %(<link href="/assets/foo.debug-#{@foo_debug_css_digest}.css" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:foo)
+      assert_dom_equal %(<link href="/assets/bar.debug-#{@bar_debug_css_digest}.css" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:bar)
+      assert_dom_equal %(<link href="/assets/file1.debug-#{@file1_debug_css_digest}.css" media="screen" rel="stylesheet" />\n<link href="/assets/file2.debug-#{@file2_debug_css_digest}.css" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:file1, :file2)
 
-    assert_servable_asset_url "/assets/foo.self-#{@foo_self_css_digest}.css?body=1"
-    assert_servable_asset_url "/assets/bar.self-#{@bar_self_css_digest}.css?body=1"
-    assert_servable_asset_url "/assets/dependency.self-#{@dependency_self_css_digest}.css?body=1"
-    assert_servable_asset_url "/assets/file1.self-#{@file1_self_css_digest}.css?body=1"
-    assert_servable_asset_url "/assets/file2.self-#{@file2_self_css_digest}.css?body=1"
+      assert_servable_asset_url "/assets/foo.self-#{@foo_self_css_digest}.css"
+      assert_servable_asset_url "/assets/bar.self-#{@bar_self_css_digest}.css"
+      assert_servable_asset_url "/assets/dependency.self-#{@dependency_self_css_digest}.css"
+      assert_servable_asset_url "/assets/file1.self-#{@file1_self_css_digest}.css"
+      assert_servable_asset_url "/assets/file2.self-#{@file2_self_css_digest}.css"
+    else
+      assert_dom_equal %(<link href="/assets/foo.self-#{@foo_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:foo)
+      assert_dom_equal %(<link href="/assets/foo.self-#{@foo_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/bar.self-#{@bar_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:bar)
+      assert_dom_equal %(<link href="/assets/dependency.self-#{@dependency_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file1.self-#{@file1_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file2.self-#{@file2_self_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
+        @view.stylesheet_link_tag(:file1, :file2)
+
+      assert_servable_asset_url "/assets/foo.self-#{@foo_self_css_digest}.css?body=1"
+      assert_servable_asset_url "/assets/bar.self-#{@bar_self_css_digest}.css?body=1"
+      assert_servable_asset_url "/assets/dependency.self-#{@dependency_self_css_digest}.css?body=1"
+      assert_servable_asset_url "/assets/file1.self-#{@file1_self_css_digest}.css?body=1"
+      assert_servable_asset_url "/assets/file2.self-#{@file2_self_css_digest}.css?body=1"
+    end
   end
 
   def test_javascript_path
@@ -676,5 +749,26 @@ class AssetUrlHelperLinksTarget < HelperTest
     env = @view.assets_environment
     assert_kind_of Sprockets::CachedEnvironment, env
     assert @view.assets_environment.equal?(env), "view didn't return the same cached instance"
+  end
+end
+
+class PrecompiledAssetHelperTest < HelperTest
+  def test_javascript_precompile
+    assert_raises(Sprockets::Rails::Helper::AssetNotPrecompiled) do
+      @view.javascript_include_tag("not_precompiled")
+    end
+  end
+
+  def test_stylesheet_precompile
+    assert_raises(Sprockets::Rails::Helper::AssetNotPrecompiled) do
+      @view.stylesheet_link_tag("not_precompiled")
+    end
+  end
+end
+
+class PrecompiledDebugAssetHelperTest < PrecompiledAssetHelperTest
+  def setup
+    super
+    @view.debug_assets = true
   end
 end

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -108,7 +108,7 @@ class TestTask < Minitest::Test
 
   def test_clean_with_keep_specified
     assert !@environment_ran
-    path     = @assets['foo.js'].pathname
+    path     = Pathname.new(@assets['foo.js'].filename)
     new_path = path.join("../foo-modified.js")
 
     FileUtils.cp(path, new_path)


### PR DESCRIPTION
Now sprockets-rails works with both, sprockets 3.x and sprockets 4.x.
The source maps debug pipeline is available when using sprockets 4.x.

The changes depend on the version of sprockets being specified. (https://github.com/rails/sprockets/pull/64)