### PR TITLE
Restore logger config (config.assets.logger)

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -54,6 +54,10 @@ module Sprockets
       end
     end
 
+    Sprockets.register_dependency_resolver 'rails-env' do
+      ::Rails.env
+    end
+
     config.assets = OrderedOptions.new
     config.assets._blocks     = []
     config.assets.paths       = []
@@ -66,43 +70,27 @@ module Sprockets
     config.assets.digest      = true
     config.assets.cache_limit = 50.megabytes
 
-
     config.assets.configure do |env|
       env.logger = config.assets.logger if config.assets.logger.present?
-    end
 
-    config.assets.configure do |env|
       config.assets.paths.each { |path| env.append_path(path) }
-    end
 
-    config.assets.configure do |env|
       env.js_compressor  = config.assets.js_compressor
       env.css_compressor = config.assets.css_compressor
-    end
 
-    config.assets.configure do |env|
       env.context_class.send :include, ::Sprockets::Rails::Context
       env.context_class.assets_prefix = config.assets.prefix
       env.context_class.digest_assets = config.assets.digest
       env.context_class.config        = config.action_controller
-    end
 
-    config.assets.configure do |env|
       env.cache = Sprockets::Cache::FileStore.new(
         "#{env.root}/tmp/cache",
         config.assets.cache_limit,
         env.logger
       )
-    end
 
-    Sprockets.register_dependency_resolver 'rails-env' do
-      ::Rails.env
-    end
-    config.assets.configure do |env|
       env.depend_on 'environment-version'
-    end
 
-    config.assets.configure do |env|
       env.version = config.assets.version
     end
 

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -66,6 +66,11 @@ module Sprockets
     config.assets.digest      = true
     config.assets.cache_limit = 50.megabytes
 
+
+    config.assets.configure do |env|
+      env.logger = config.assets.logger if config.assets.logger.present?
+    end
+
     config.assets.configure do |env|
       config.assets.paths.each { |path| env.append_path(path) }
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -376,14 +376,14 @@ class DigestHelperTest < NoHostHelperTest
     assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js"></script>),
       @view.javascript_include_tag("foo", integrity: nil)
 
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha-256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
       @view.javascript_include_tag("foo", integrity: true)
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha-256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
       @view.javascript_include_tag("foo.js", integrity: true)
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha-256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>),
       @view.javascript_include_tag(:foo, integrity: true)
 
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha-256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>\n<script src="/assets/bar-#{@bar_js_digest}.js" integrity="sha-256-g0JYFeYSYGXe376R0JrRzS6CpYpC1HiqtwBsVt/XAWU="></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="sha256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>\n<script src="/assets/bar-#{@bar_js_digest}.js" integrity="sha256-g0JYFeYSYGXe376R0JrRzS6CpYpC1HiqtwBsVt/XAWU="></script>),
       @view.javascript_include_tag(:foo, :bar, integrity: true)
   end
 
@@ -395,14 +395,14 @@ class DigestHelperTest < NoHostHelperTest
     assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag("foo", integrity: nil)
 
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha-256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
       @view.stylesheet_link_tag("foo", integrity: true)
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha-256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
       @view.stylesheet_link_tag("foo.css", integrity: true)
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha-256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />),
       @view.stylesheet_link_tag(:foo, integrity: true)
 
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha-256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />\n<link href="/assets/bar-#{@bar_css_digest}.css" media="screen" rel="stylesheet" integrity="sha-256-Vd370+VAW4D96CVpZcjFLXyeHoagI0VHwofmzRXetuE=" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="sha256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=" />\n<link href="/assets/bar-#{@bar_css_digest}.css" media="screen" rel="stylesheet" integrity="sha256-Vd370+VAW4D96CVpZcjFLXyeHoagI0VHwofmzRXetuE=" />),
       @view.stylesheet_link_tag(:foo, :bar, integrity: true)
   end
 

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -110,6 +110,30 @@ class TestRailtie < TestBoot
     assert_equal File.join(ROOT, "public/assets"), manifest.dir
   end
 
+  def test_logger
+    # Sprockets by default logs at level FATAL to $stderr
+    expected_logger = Logger.new($stderr)
+    expected_logger.level = Logger::FATAL
+
+    app.initialize!
+    assert env = app.assets
+    # env.logger should have the same @level, @formatter, @filename, and @dev
+    # as expected_logger (though different object ids)
+    assert_equal env.logger.inspect.split.reject {|a| a =~ /:0x/},
+                 expected_logger.inspect.split.reject {|a| a =~ /:0x/}
+  end
+
+  def test_custom_logger
+    custom_logger = Logger.new('log/sprockets.log')
+    app.configure do
+      config.assets.logger = custom_logger
+    end
+    app.initialize!
+
+    assert env = app.assets
+    assert_equal env.logger, custom_logger
+  end
+
   def test_copies_paths
     app.configure do
       config.assets.paths << "javascripts"


### PR DESCRIPTION
Not sure when this was removed, but I assume it was inadvertent since it's still in the docs.

At present, config.assets.logger is not being used by sprockets; nothing will be written to the logger you provide in your config.