### PR TITLE
Fix performance regression in Rails helper

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -21,7 +21,7 @@ module Sprockets
       include Sprockets::Rails::Utils
 
       VIEW_ACCESSORS = [:assets_environment, :assets_manifest,
-                        :assets_precompile,
+                        :assets_precompile, :precompiled_assets,
                         :assets_prefix, :digest_assets, :debug_assets]
 
       def self.included(klass)
@@ -226,11 +226,6 @@ module Sprockets
           end
 
           asset
-        end
-
-        # Internal: Generate a Set of all precompiled assets logical paths.
-        def precompiled_assets
-          @precompiled_assets ||= assets_manifest.find(assets_precompile || []).map(&:logical_path)
         end
     end
   end

--- a/lib/sprockets/rails/utils.rb
+++ b/lib/sprockets/rails/utils.rb
@@ -6,6 +6,11 @@ module Sprockets
       def using_sprockets4?
         Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new('4.0.0')
       end
+
+      # Internal: Generate a Set of all precompiled assets logical paths.
+      def build_precompiled_list(manifest, assets)
+        manifest.find(assets || []).map(&:logical_path)
+      end
     end
   end
 end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -26,6 +26,9 @@ module Rails
 
     # Returns Sprockets::Manifest for app config.
     attr_accessor :assets_manifest
+
+    # Returns array of already precompiled assets
+    attr_accessor :precompiled_assets
   end
 
   class Engine < Railtie
@@ -150,8 +153,11 @@ module Sprockets
         app.routes.prepend do
           mount app.assets => config.assets.prefix
         end
+        app.assets_manifest = build_manifest(app)
+        app.precompiled_assets = build_precompiled_list(app.assets_manifest, config.assets.precompile)
+      else
+        app.assets_manifest = build_manifest(app)
       end
-      app.assets_manifest = build_manifest(app)
 
       ActionDispatch::Routing::RouteWrapper.class_eval do
         class_attribute :assets_prefix
@@ -176,6 +182,7 @@ module Sprockets
 
         self.assets_environment = app.assets
         self.assets_manifest = app.assets_manifest
+        self.precompiled_assets = app.precompiled_assets
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,6 +25,7 @@ class HelperTest < ActionView::TestCase
     @view.assets_manifest    = @manifest
     @view.assets_prefix      = "/assets"
     @view.assets_precompile  = %w( manifest.js )
+    @view.precompiled_assets = @view.build_precompiled_list(@manifest, @view.assets_precompile)
     @view.request = ActionDispatch::Request.new({
       "rack.url_scheme" => "https"
     })
@@ -729,6 +730,7 @@ end
 class AssetUrlHelperLinksTarget < HelperTest
   def test_precompile_allows_links
     @view.assets_precompile = ["url.css"]
+    @view.precompiled_assets = @view.build_precompiled_list(@manifest, @view.assets_precompile)
     assert @view.asset_path("url.css")
     assert @view.asset_path("logo.png")
 


### PR DESCRIPTION
This fixes the regression reported in #234 that @dhh reported. As noted in the commit message that code was a red herring. The problem was that the cache on `precompiled_assets` was being reset every single time by CachedEnvironment because it didn't pull `precompiled_assets` over.

This change moves that method to the Railtie class so that it remains in the env. 

If you want to test this out I made a brand new application to demonstrate the issue and test with (https://github.com/eileencodes/perf_regression_sprockets). 

This regression shows up on running tests that render assets - show that renders a template with application.js and application.css.

cc/ @jeremy 

---

Fix performance regression in Rails helper

Previously reported performance regression #234 was a red herring. The
`Engine` class and addition of adding `app/` asset path appears to be a
big problem, but the reason it's slow is because then it would run
through `precompiled_assets` where without that code it skips
`precompiled_assets` thus skipping the code that is actually slow.

Although `precompiled_assets` was memoized the cache wasn't actually
working and the method cache was being thrown away every single time.
This became very obvious when our test suite (Basecamp) went from 54
seconds to 320 seconds to run on sprockets-rails master.

The problem is that when the env is reset the `precompiled_assets` gets
reset instead of keeping the cache. I moved this method onto the config
to behave like the other methods, for example `assets_manifest`.

Benchmarks:
On a brand new application with a single show test that simply renders a
view with a few assets.

Before this change:
```
Calculating -------------------------------------
     Running test...    27.000  i/100ms
-------------------------------------------------
     Running test...    305.554  (± 8.2%) i/s -      1.539k
```

After this change:
```
Calculating -------------------------------------
     Running test...    55.000  i/100ms
-------------------------------------------------
     Running test...    558.135  (± 5.4%) i/s -      2.805k
```