### PR TITLE
Add config.assets.cache_path

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -74,6 +74,7 @@ module Sprockets
     config.assets.compile     = true
     config.assets.digest      = true
     config.assets.cache_limit = 50.megabytes
+    config.assets.cache_path  = nil
 
     config.assets.configure do |env|
       config.assets.paths.each { |path| env.append_path(path) }
@@ -88,7 +89,7 @@ module Sprockets
 
     config.assets.configure do |env|
       env.cache = Sprockets::Cache::FileStore.new(
-        "#{env.root}/tmp/cache",
+        config.assets.cache_path || "#{env.root}/tmp/cache",
         config.assets.cache_limit,
         env.logger
       )


### PR DESCRIPTION
Make it easy to customize the cache path without having to re-specify
the whole FileStore.