### PR TITLE
Fix SRI example hash in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Sprockets 3.x adds experimental support for subresource integrity checks. The sp
 
 ``` ruby
 javascript_include_tag :application, integrity: true
-# => "<script src="/assets/application.js" integrity="sha-256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>"
+# => "<script src="/assets/application.js" integrity="sha256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>"
 ```
 
 


### PR DESCRIPTION
The `integrity` attribute doesn't include a dash in the digest name.