### PR TITLE
Speed up app boot by deferring asset precompile

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -21,7 +21,7 @@ module Sprockets
       include Sprockets::Rails::Utils
 
       VIEW_ACCESSORS = [:assets_environment, :assets_manifest,
-                        :assets_precompile, :precompiled_assets,
+                        :assets_precompile, :precompiled_asset_checker,
                         :assets_prefix, :digest_assets, :debug_assets]
 
       def self.included(klass)
@@ -82,7 +82,7 @@ module Sprockets
         if environment = assets_environment
           if asset = environment[path]
             unless options[:debug]
-              if !precompiled_assets.include?(asset.logical_path)
+              if !precompiled_asset_checker.call(asset.logical_path)
                 raise AssetNotPrecompiled.new(asset.logical_path)
               end
             end
@@ -220,7 +220,7 @@ module Sprockets
 
           if asset = env[path, pipeline: :debug]
             original_path = asset.logical_path.gsub('.debug', '')
-            unless precompiled_assets.include?(original_path)
+            unless precompiled_asset_checker.call(original_path)
               raise AssetNotPrecompiled.new(original_path)
             end
           end

--- a/lib/sprockets/rails/utils.rb
+++ b/lib/sprockets/rails/utils.rb
@@ -6,11 +6,6 @@ module Sprockets
       def using_sprockets4?
         Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new('4.0.0')
       end
-
-      # Internal: Generate a Set of all precompiled assets logical paths.
-      def build_precompiled_list(manifest, assets)
-        manifest.find(assets || []).map(&:logical_path)
-      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,8 @@ class HelperTest < ActionView::TestCase
     @view.assets_manifest    = @manifest
     @view.assets_prefix      = "/assets"
     @view.assets_precompile  = %w( manifest.js )
-    @view.precompiled_assets = @view.build_precompiled_list(@manifest, @view.assets_precompile)
+    precompiled_assets = @manifest.find(@view.assets_precompile).map(&:logical_path)
+    @view.precompiled_asset_checker = -> logical_path { precompiled_assets.include? logical_path }
     @view.request = ActionDispatch::Request.new({
       "rack.url_scheme" => "https"
     })
@@ -730,7 +731,8 @@ end
 class AssetUrlHelperLinksTarget < HelperTest
   def test_precompile_allows_links
     @view.assets_precompile = ["url.css"]
-    @view.precompiled_assets = @view.build_precompiled_list(@manifest, @view.assets_precompile)
+    precompiled_assets = @manifest.find(@view.assets_precompile).map(&:logical_path)
+    @view.precompiled_asset_checker = -> logical_path { precompiled_assets.include? logical_path }
     assert @view.asset_path("url.css")
     assert @view.asset_path("logo.png")
 


### PR DESCRIPTION
* Lazy-load precompiled asset list so it doesn't block boot time
* Memoize it on the app so it doesn't get flushed along with AV instances
* References #265 and #234.

cc @eileencodes 