### PR TITLE
Drop toplevel `app/assets` load path

### DIFF
--- a/lib/sprockets/rails/version.rb
+++ b/lib/sprockets/rails/version.rb
@@ -1,5 +1,5 @@
 module Sprockets
   module Rails
-    VERSION = "3.0.0.beta2"
+    VERSION = "3.0.0.beta3"
   end
 end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -47,7 +47,6 @@ module Rails
       initializer :append_assets_path, :group => :all do |app|
         app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
         app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
-        app.config.assets.paths.unshift(*paths["app"].existent_directories.grep(/\/assets\z/))
         app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)
       end
     end


### PR DESCRIPTION
`app/assets` was added to give `manifest.js` a place to live, but it suggests that `require 'stylesheets/foo.css'` might be the right way to refer to `require 'foo.css'`.

We resolve the overlap and clarify that `manifest.js` is configuration by moving it from `app/assets/` to `app/assets/config/`. Put it up on a pedestal: https://github.com/rails/rails/pull/21794

This reverts #232 and commit 39ecb27f8a8903619e3aa412927fc48ae42c8323, reversing changes made to 3a44d472cca3b7ed924b330c5af1e04de78841af.