### PR TITLE
Restore manifest/env asset lookup order and make it configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,6 @@ config.assets.version = 'v2'
 
 Defaults to `/assets`. Changes the directory to compile assets to.
 
-**`config.assets.manifest`**
-
-Defines the full path to be used for the asset precompiler's manifest file. Defaults to a randomly-generated filename in the `config.assets.prefix` directory within the public folder.
-
 **`config.assets.digest`**
 
 When enabled, fingerprints will be added to asset filenames.
@@ -106,6 +102,24 @@ config.assets.configure do |env|
 
   env.cache = ActiveSupport::Cache::FileStore.new("tmp/cache/assets")
 end
+```
+
+**`config.assets.resolve_with`**
+
+A list of `:environment` and `:manifest` symbols that defines the order that
+we try to find assets: manifest first, environment second? Manifest only?
+
+By default, we check the manifest first if asset digests are enabled and debug
+is not enabled, then we check the environment if compiling is enabled:
+```
+# Dev where debug is true, or digests are disabled
+%i[ environment ]
+
+# Dev default, or production with compile enabled.
+%i[ manifest environment ]
+
+# Production default.
+%i[ manifest ]
 ```
 
 

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -166,7 +166,14 @@ module Sprockets
           mount app.assets => config.assets.prefix
         end
       end
+
       app.assets_manifest = build_manifest(app)
+
+      if config.assets.resolve_with.nil?
+        config.assets.resolve_with = []
+        config.assets.resolve_with << :manifest if config.assets.digest && !config.assets.debug
+        config.assets.resolve_with << :environment if config.assets.compile
+      end
 
       ActionDispatch::Routing::RouteWrapper.class_eval do
         class_attribute :assets_prefix
@@ -191,6 +198,8 @@ module Sprockets
 
         self.assets_environment = app.assets
         self.assets_manifest = app.assets_manifest
+
+        self.resolve_assets_with = config.assets.resolve_with
 
         # Expose the app precompiled asset check to the view
         self.precompiled_asset_checker = -> logical_path { app.asset_precompiled? logical_path }


### PR DESCRIPTION
* Revert env-first lookup order from #276 to support using both manifest and a live environment in production.
* Default to manifest first, env second. Skip manifest if debug enabled or digests disabled. Skip env if it's unavailable.
* Override with `config.assets.resolve_with = %i[ manifest environment ]`