### PR TITLE
add README note for config flag conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ is not enabled, then we check the environment if compiling is enabled:
 # Production default.
 %i[ manifest ]
 ```
-
+If the resolver list is empty (e.g. if debug is true and compile is false), the standard rails public path resolution will be used.
 
 ## Complementary plugins
 


### PR DESCRIPTION
Ran into this in a legacy project (https://github.com/rails/sprockets-rails/issues/312). Not sure if this is the best way to help others, but I wanted to suggest something that might help.

Example:
If debug is true and compile is false, assets will not be resolved
by sprockets and will fall back to the standard rails public dir
resolution.

In this situation
  `stylesheet_link_tag('application')` will resolve to
  `/stylesheets/application.css` instead of
  `/assets/application.css`