### PR TITLE
Change default cache location back to original

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,6 @@ config.assets.configure do |env|
   env.register_preprocessor 'application/javascript', MyProcessor
 
   env.logger = Rails.logger
-
-  env.cache = ActiveSupport::Cache::FileStore.new("tmp/cache/assets")
 end
 ```
 

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -98,7 +98,7 @@ module Sprockets
 
     config.assets.configure do |env|
       env.cache = Sprockets::Cache::FileStore.new(
-        "#{env.root}/tmp/cache",
+        "#{env.root}/tmp/cache/assets",
         config.assets.cache_limit,
         env.logger
       )


### PR DESCRIPTION
In this commit https://github.com/rails/sprockets-rails/commit/80164cb0b3eae7dc8a6efab7553a7a8ab4e20c10 the `assets` folder looks to be accidentally removed from the cache file store. This causes problems if you're specifically moving that folder between builds.