### PR TITLE
Fix the precompile checker with bundle files

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -313,15 +313,15 @@ module Sprockets
 
           # Otherwise, ask the Sprockets environment whether the asset exists
           # and check whether it's also precompiled for production deploys.
-          elsif find_asset(path)
-            raise_unless_precompiled_asset path unless allow_non_precompiled
+          elsif asset = find_asset(path)
+            raise_unless_precompiled_asset asset.logical_path unless allow_non_precompiled
             path
           end
         end
 
         def digest_path(path, allow_non_precompiled = false)
           if asset = find_asset(path)
-            raise_unless_precompiled_asset path unless allow_non_precompiled
+            raise_unless_precompiled_asset asset.logical_path unless allow_non_precompiled
             asset.digest_path
           end
         end

--- a/test/fixtures/manifest.js
+++ b/test/fixtures/manifest.js
@@ -7,3 +7,4 @@
 //= link file1.js
 //= link file2.css
 //= link file2.js
+//= link bundle.js

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -803,6 +803,11 @@ class AssetUrlHelperLinksTarget < HelperTest
 end
 
 class PrecompiledAssetHelperTest < HelperTest
+  def setup
+    super
+    @bundle_js_name = '/assets/bundle.js'
+  end
+
   def test_javascript_precompile
     assert_raises(Sprockets::Rails::Helper::AssetNotPrecompiled) do
       @view.javascript_include_tag("not_precompiled")
@@ -814,11 +819,17 @@ class PrecompiledAssetHelperTest < HelperTest
       @view.stylesheet_link_tag("not_precompiled")
     end
   end
+
+  def test_index_files
+    assert_dom_equal %(<script src="#{@bundle_js_name}"></script>),
+      @view.javascript_include_tag("bundle")
+  end
 end
 
 class PrecompiledDebugAssetHelperTest < PrecompiledAssetHelperTest
   def setup
     super
     @view.debug_assets = true
+    @bundle_js_name = '/assets/bundle/index.self.js?body=1'
   end
 end


### PR DESCRIPTION
Sprockets allow you to create bundles using `bundle_name/index.js` as the file name. If you declare `bundle_name` in your manifest you should not get an `AssetNotPrecompiled` error.