### PR TITLE
Update railtie to ignore no-extension files

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -60,7 +60,7 @@ module Sprockets
 
     LOOSE_APP_ASSETS = lambda do |logical_path, filename|
         filename.start_with?(::Rails.root.join("app/assets").to_s) &&
-        !%w(.js .css).include?(File.extname(logical_path))
+        !['.js', '.css', ''].include?(File.extname(logical_path))
     end
 
     class OrderedOptions < ActiveSupport::OrderedOptions


### PR DESCRIPTION
Updated the railtie to ignore files with no extensions, such as LICENSE, that cause sprockets to error out on assets compilation.