### PR TITLE
Better Errors

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -11,14 +11,10 @@ module Sprockets
         def initialize(source)
           msg =
           if using_sprockets4?
-            "Asset `#{source}` was not declared to be precompiled in production.\n" +
-            "Declare links to your assets in `assets/config/manifest.js`.\n" +
-            "Examples:\n" +
-            "`//= link ../javascripts/application.js`\n" +
-            "`//= link_directory ../javascripts .js`\n" +
-            "`//= link_directory ../stylesheets .css`\n" +
-            "`//= link_tree ../javascripts .js`\n" +
-            "`//= link_tree ../images`\n"
+            "Asset `#{ source }` was not declared to be precompiled in production.\n" +
+            "Declare links to your assets in `app/assets/config/manifest.js`.\n\n" +
+            "  //= link #{ source }\n" +
+            "and restart your server"
           else
             "Asset was not declared to be precompiled in production.\n" +
             "Add `Rails.application.config.assets.precompile += " +

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -38,6 +38,14 @@ class TestBoot < Minitest::Test
     @app.config.middleware ||= Rails::Configuration::MiddlewareStackProxy.new
     @app.config.active_support.deprecation = :notify
     ActionView::Base # load ActionView
+
+    Dir.chdir(app.root) do
+      dir = "app/assets/config"
+      FileUtils.mkdir_p(dir)
+      File.open("#{ dir }/manifest.js", "w") do |f|
+        f << ""
+      end
+    end
   end
 
   def test_initialize
@@ -72,7 +80,7 @@ class TestRailtie < TestBoot
     assert_equal ROOT, env.root
     assert_equal "", env.version
     assert env.cache
-    assert_equal [], env.paths
+    assert_equal ["#{ROOT}/app/assets/config"], env.paths
     assert_nil env.js_compressor
     assert_nil env.css_compressor
   end
@@ -120,7 +128,7 @@ class TestRailtie < TestBoot
     app.initialize!
 
     assert env = app.assets
-    assert_equal ["#{ROOT}/javascripts", "#{ROOT}/stylesheets"],
+    assert_equal ["#{ROOT}/app/assets/config", "#{ROOT}/javascripts", "#{ROOT}/stylesheets"],
       env.paths.sort
   end
 
@@ -179,7 +187,7 @@ class TestRailtie < TestBoot
     app.initialize!
 
     assert env = app.assets
-    assert_equal ["#{ROOT}/javascripts", "#{ROOT}/stylesheets"],
+    assert_equal ["#{ROOT}/app/assets/config", "#{ROOT}/javascripts", "#{ROOT}/stylesheets"],
       env.paths.sort
   end
 
@@ -340,7 +348,7 @@ class TestRailtie < TestBoot
     assert_kind_of Sprockets::Environment, env
 
     assert_equal ROOT, env.root
-    assert_equal ["#{ROOT}/javascripts", "#{ROOT}/stylesheets"],
+    assert_equal ["#{ROOT}/app/assets/config", "#{ROOT}/javascripts", "#{ROOT}/stylesheets"],
       env.paths.sort
   end
 end


### PR DESCRIPTION
Raise a descriptive error if specific config file `app/assets/config/manifest.js` is not found when using Sprockets 4.

The `link ../javascripts/application.js` link does not work for me on codetriage.com but `link application.js` does.

The error when a source isn't found should only show how to add that specific source for maximum clarity.
