### PR TITLE
[Close #321] Clear Asset precompile cache on request

### DIFF
--- a/lib/sprockets/rails/flush_cache_middleware.rb
+++ b/lib/sprockets/rails/flush_cache_middleware.rb
@@ -1,0 +1,18 @@
+module Sprockets
+  module Rails
+    # A middleware used for clearing memoized asset cache data once per request
+    # https://github.com/rails/sprockets-rails/issues/321#issuecomment-188313036
+    class FlushCacheMiddleware
+
+      def initialize(app, clear_cache)
+        @app         = app
+        @clear_cache = clear_cache
+      end
+
+      def call(env)
+        @clear_cache.call
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -18,8 +18,7 @@ module Sprockets
             "`//= link_directory ../javascripts .js`\n" +
             "`//= link_directory ../stylesheets .css`\n" +
             "`//= link_tree ../javascripts .js`\n" +
-            "`//= link_tree ../images`\n" +
-            "and restart your server"
+            "`//= link_tree ../images`\n"
           else
             "Asset was not declared to be precompiled in production.\n" +
             "Add `Rails.application.config.assets.precompile += " +


### PR DESCRIPTION
When in debug mode we want to see if any new files have been added to our precompile list by nature of them being added to disk. For example if you add an image  to `images` and you have linked the directory:

```
//= link_directory ../images
```

This change also eliminates the need to restart the server in development when changes are made when using a manifest.js and Sprockets 4.