### PR TITLE
[Close #321] Double check precompile missing asset

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -18,8 +18,7 @@ module Sprockets
             "`//= link_directory ../javascripts .js`\n" +
             "`//= link_directory ../stylesheets .css`\n" +
             "`//= link_tree ../javascripts .js`\n" +
-            "`//= link_tree ../images`\n" +
-            "and restart your server"
+            "`//= link_tree ../images`\n"
           else
             "Asset was not declared to be precompiled in production.\n" +
             "Add `Rails.application.config.assets.precompile += " +

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -31,13 +31,21 @@ module Rails
     # Called from asset helpers to alert you if you reference an asset URL that
     # isn't precompiled and hence won't be available in production.
     def asset_precompiled?(logical_path)
-      precompiled_assets.include? logical_path
+      if precompiled_assets.include?(logical_path)
+        true
+      elsif !config.cache_classes
+        # Check to see if precompile list has been updated
+        precompiled_assets(true).include?(logical_path)
+      else
+        false
+      end
     end
 
     # Lazy-load the precompile list so we don't cause asset compilation at app
     # boot time, but ensure we cache the list so we don't recompute it for each
     # request or test case.
-    def precompiled_assets
+    def precompiled_assets(clear_cache = false)
+      @precompiled_assets = nil if clear_cache
       @precompiled_assets ||= assets_manifest.find(config.assets.precompile).map(&:logical_path).to_set
     end
   end


### PR DESCRIPTION
When in classes are not cached, we're not in a state where performance matters as much (like development mode) we want to see if any new files have been added to our precompile list by nature of them being added to disk. For example if you add an image  to `images` and you have linked the directory:

```
//= link_directory ../images
```

This change also eliminates the need to restart the server in development when changes are made when using a manifest.js and Sprockets 4.

cc/ @matthewd 