### PR TITLE
Disentangle 'debug' and 'allow_non_precompiled' asset path options

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -70,8 +70,10 @@ module Sprockets
 
       def compute_asset_path(path, options = {})
         debug = options[:debug]
+        allow_non_precompiled = options.key?(:allow_non_precompiled) ?
+          options[:allow_non_precompiled] : debug
 
-        if asset_path = resolve_asset_path(path, debug)
+        if asset_path = resolve_asset_path(path, allow_non_precompiled)
           File.join(assets_prefix || "/", legacy_debug_path(asset_path, debug))
         else
           super


### PR DESCRIPTION
This will allow us to close [issue 297](https://github.com/rails/sprockets-rails/issues/297) that sprung out of integrating Teaspoon with Rails. The crux of the issue is that attempting to load any asset not listed for pre-compilation results in an ```Sprockets::Rails::Helper::AssetNotPrecompiled``` error.

To recreate the issue attempt loading an asset not declared from pre-compilation like so:
```
<%= javascript_include_tag 'dummy', 'debug' => false, 'allow_non_precompiled' => true %>
```
with the following setup:
```
rails 4.2.6
sprockets 3.6.0
sprockets-rails 3.0.4
```

Internally sprockets-rails already has all the flags for loading an asset this way but the 'allow_non_precomiled' flag is ignored. This fixes that will falling back on the 'debug' flag when 'allow_non_precomiled' is not declared so that users can still rely on the old behaviour.

Please not that for the call to ```javascript_include_tag``` to actually work will additionally require ```ActionView::Helpers::AssetTagHelper#javascript_include_tag``` to pass along the 'allow_non_precompiled' (and 'debug') flags when generating the asset path. That will be dealt with as a second step. With this fix at least the following can now work:
```
<%= javascript_include_tag path_to_javascript('dummy', debug: false, allow_non_precompiled: true) %>
```