### PR TITLE
add option to make raising exception for missing assets optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ is not enabled, then we check the environment if compiling is enabled:
 ```
 If the resolver list is empty (e.g. if debug is true and compile is false), the standard rails public path resolution will be used.
 
+**`config.assets.raise_unless_precompiled_asset`**
+
+When enabled, an exception is raised for missing assets. This option is enabled by default.
+
 ## Complementary plugins
 
 The following plugins provide some extras for the Sprockets Asset Pipeline.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ is not enabled, then we check the environment if compiling is enabled:
 ```
 If the resolver list is empty (e.g. if debug is true and compile is false), the standard rails public path resolution will be used.
 
-**`config.assets.raise_unless_precompiled_asset`**
+**`config.assets.check_precompiled_asset`**
 
 When enabled, an exception is raised for missing assets. This option is enabled by default.
 

--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -33,7 +33,7 @@ module Sprockets
         :assets_environment, :assets_manifest,
         :assets_precompile, :precompiled_asset_checker,
         :assets_prefix, :digest_assets, :debug_assets,
-        :resolve_assets_with
+        :resolve_assets_with, :raise_unless_precompiled_asset
       ]
 
       def self.included(klass)
@@ -299,6 +299,7 @@ module Sprockets
           raise ArgumentError, 'config.assets.resolve_with includes :environment, but app.assets is nil' unless view.assets_environment
           @env = view.assets_environment
           @precompiled_asset_checker = view.precompiled_asset_checker
+          @raise_unless_precompiled_asset = view.raise_unless_precompiled_asset
         end
 
         def asset_path(path, digest, allow_non_precompiled = false)
@@ -342,6 +343,7 @@ module Sprockets
           end
 
           def raise_unless_precompiled_asset(path)
+            return unless @raise_unless_precompiled_asset
             raise Helper::AssetNotPrecompiled.new(path) unless precompiled?(path)
           end
       end

--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -33,7 +33,7 @@ module Sprockets
         :assets_environment, :assets_manifest,
         :assets_precompile, :precompiled_asset_checker,
         :assets_prefix, :digest_assets, :debug_assets,
-        :resolve_assets_with, :raise_unless_precompiled_asset
+        :resolve_assets_with, :check_precompiled_asset
       ]
 
       def self.included(klass)
@@ -299,7 +299,7 @@ module Sprockets
           raise ArgumentError, 'config.assets.resolve_with includes :environment, but app.assets is nil' unless view.assets_environment
           @env = view.assets_environment
           @precompiled_asset_checker = view.precompiled_asset_checker
-          @raise_unless_precompiled_asset = view.raise_unless_precompiled_asset
+          @check_precompiled_asset = view.check_precompiled_asset
         end
 
         def asset_path(path, digest, allow_non_precompiled = false)
@@ -343,8 +343,7 @@ module Sprockets
           end
 
           def raise_unless_precompiled_asset(path)
-            return unless @raise_unless_precompiled_asset
-            raise Helper::AssetNotPrecompiled.new(path) unless precompiled?(path)
+            raise Helper::AssetNotPrecompiled.new(path) if @check_precompiled_asset && !precompiled?(path)
           end
       end
     end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -113,6 +113,7 @@ module Sprockets
     config.assets.digest      = true
     config.assets.cache_limit = 50.megabytes
     config.assets.gzip        = true
+    config.assets.raise_unless_precompiled_asset = true
 
     config.assets.configure do |env|
       config.assets.paths.each { |path| env.append_path(path) }
@@ -234,6 +235,8 @@ module Sprockets
         self.assets_manifest = app.assets_manifest
 
         self.resolve_assets_with = config.assets.resolve_with
+
+        self.raise_unless_precompiled_asset = config.assets.raise_unless_precompiled_asset
 
         # Expose the app precompiled asset check to the view
         self.precompiled_asset_checker = -> logical_path { app.asset_precompiled? logical_path }

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -113,7 +113,7 @@ module Sprockets
     config.assets.digest      = true
     config.assets.cache_limit = 50.megabytes
     config.assets.gzip        = true
-    config.assets.raise_unless_precompiled_asset = true
+    config.assets.check_precompiled_asset = true
 
     config.assets.configure do |env|
       config.assets.paths.each { |path| env.append_path(path) }
@@ -236,7 +236,7 @@ module Sprockets
 
         self.resolve_assets_with = config.assets.resolve_with
 
-        self.raise_unless_precompiled_asset = config.assets.raise_unless_precompiled_asset
+        self.check_precompiled_asset = config.assets.check_precompiled_asset
 
         # Expose the app precompiled asset check to the view
         self.precompiled_asset_checker = -> logical_path { app.asset_precompiled? logical_path }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,7 @@ class HelperTest < ActionView::TestCase
     @view.assets_prefix       = "/assets"
     @view.assets_precompile   = %w( manifest.js )
     precompiled_assets = @manifest.find(@view.assets_precompile).map(&:logical_path)
+    @view.raise_unless_precompiled_asset = true
     @view.precompiled_asset_checker = -> logical_path { precompiled_assets.include? logical_path }
     @view.request = ActionDispatch::Request.new({
       "rack.url_scheme" => "https"
@@ -823,6 +824,20 @@ class PrecompiledAssetHelperTest < HelperTest
   def test_index_files
     assert_dom_equal %(<script src="#{@bundle_js_name}"></script>),
       @view.javascript_include_tag("bundle")
+  end
+end
+
+class RaiseUnlessPrecompiledAssetDisabledTest < HelperTest
+  def test_raise_unless_precompiled_asset_enabled
+    @view.raise_unless_precompiled_asset = true
+    assert_raises(Sprockets::Rails::Helper::AssetNotPrecompiled) do
+      @view.asset_path("not_precompiled.css")
+    end
+  end
+
+  def test_raise_unless_precompiled_asset_disabled
+    @view.raise_unless_precompiled_asset = false
+    assert @view.asset_path("not_precompiled.css")
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,7 @@ class HelperTest < ActionView::TestCase
     @view.assets_prefix       = "/assets"
     @view.assets_precompile   = %w( manifest.js )
     precompiled_assets = @manifest.find(@view.assets_precompile).map(&:logical_path)
-    @view.raise_unless_precompiled_asset = true
+    @view.check_precompiled_asset = true
     @view.precompiled_asset_checker = -> logical_path { precompiled_assets.include? logical_path }
     @view.request = ActionDispatch::Request.new({
       "rack.url_scheme" => "https"
@@ -828,15 +828,15 @@ class PrecompiledAssetHelperTest < HelperTest
 end
 
 class RaiseUnlessPrecompiledAssetDisabledTest < HelperTest
-  def test_raise_unless_precompiled_asset_enabled
-    @view.raise_unless_precompiled_asset = true
+  def test_check_precompiled_asset_enabled
+    @view.check_precompiled_asset = true
     assert_raises(Sprockets::Rails::Helper::AssetNotPrecompiled) do
       @view.asset_path("not_precompiled.css")
     end
   end
 
-  def test_raise_unless_precompiled_asset_disabled
-    @view.raise_unless_precompiled_asset = false
+  def test_check_precompiled_asset_disabled
+    @view.check_precompiled_asset = false
     assert @view.asset_path("not_precompiled.css")
   end
 end

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -182,20 +182,20 @@ class TestRailtie < TestBoot
     assert_equal false, env.gzip?
   end
 
-  def test_default_raise_unless_precompiled_assets
-    assert app.config.assets.raise_unless_precompiled_asset
+  def test_default_check_precompiled_assets
+    assert app.config.assets.check_precompiled_asset
     app.initialize!
     @view = ActionView::Base.new
-    assert @view.raise_unless_precompiled_asset
+    assert @view.check_precompiled_asset
   end
 
-  def test_configure_raise_unless_precompiled_assets
+  def test_configure_check_precompiled_assets
     app.configure do
-      config.assets.raise_unless_precompiled_asset = false
+      config.assets.check_precompiled_asset = false
     end
     app.initialize!
     @view = ActionView::Base.new
-    refute @view.raise_unless_precompiled_asset
+    refute @view.check_precompiled_asset
   end
 
   def test_version

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -182,6 +182,22 @@ class TestRailtie < TestBoot
     assert_equal false, env.gzip?
   end
 
+  def test_default_raise_unless_precompiled_assets
+    assert app.config.assets.raise_unless_precompiled_asset
+    app.initialize!
+    @view = ActionView::Base.new
+    assert @view.raise_unless_precompiled_asset
+  end
+
+  def test_configure_raise_unless_precompiled_assets
+    app.configure do
+      config.assets.raise_unless_precompiled_asset = false
+    end
+    app.initialize!
+    @view = ActionView::Base.new
+    refute @view.raise_unless_precompiled_asset
+  end
+
   def test_version
     app.configure do
       config.assets.version = 'v2'


### PR DESCRIPTION
@rafaelfranca this PR makes it possible to disable the exception for a missing asset (but still does by default)

tested in a real use-case and this does appear to eliminate the previously discussed first-request delay

let me know if this needs anything more