### PR TITLE
Silence asset requests with config.assets.quiet 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Add additional assets to compile on deploy. Defaults to `application.js`, `appli
 
 Add additional load paths to this Array. Rails includes `app/assets`, `lib/assets` and `vendor/assets` for you already. Plugins might want to add their custom paths to this.
 
+**`config.assets.quiet`**
+
+Suppresses logger output for asset requests. Uses the `config.assets.prefix` path to match and wraps the request in a `Rails.logger.silence{ }` which silences all but `ERROR` level. Defaults to `false`.
 
 **`config.assets.version`**
 

--- a/lib/sprockets/rails/quiet_assets.rb
+++ b/lib/sprockets/rails/quiet_assets.rb
@@ -1,0 +1,18 @@
+module Sprockets
+  module Rails
+    class QuietAssets
+      def initialize(app)
+        @app = app
+        @assets_regex = %r(\A/{0,2}#{::Rails.application.config.assets.prefix})
+      end
+
+      def call(env)
+        if env['PATH_INFO'] =~ @assets_regex
+          ::Rails.logger.silence { @app.call(env) }
+        else
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -6,6 +6,7 @@ require 'active_support/core_ext/numeric/bytes'
 require 'sprockets'
 require 'sprockets/rails/context'
 require 'sprockets/rails/helper'
+require 'sprockets/rails/quiet_assets'
 require 'sprockets/rails/route_wrapper'
 require 'sprockets/rails/version'
 require 'set'
@@ -97,6 +98,7 @@ module Sprockets
     config.assets.precompile  = []
     config.assets.prefix      = "/assets"
     config.assets.manifest    = nil
+    config.assets.quiet       = false
 
     initializer :set_default_precompile do |app|
       if using_sprockets4?
@@ -104,6 +106,12 @@ module Sprockets
         app.config.assets.precompile  += %w( manifest.js )
       else
         app.config.assets.precompile  += [LOOSE_APP_ASSETS, /(?:\/|\\|\A)application\.(css|js)$/]
+      end
+    end
+
+    initializer :quiet_assets do |app|
+      if app.config.assets.quiet
+        app.middleware.insert_before ::Rails::Rack::Logger, ::Sprockets::Rails::QuietAssets
       end
     end
 

--- a/test/test_quiet_assets.rb
+++ b/test/test_quiet_assets.rb
@@ -1,0 +1,51 @@
+require 'active_support'
+require 'active_support/testing/isolation'
+require 'active_support/log_subscriber/test_helper'
+require 'minitest/autorun'
+
+require 'sprockets/railtie'
+require 'rails'
+
+Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
+
+class TestQuietAssets < Minitest::Test
+  include ActiveSupport::Testing::Isolation
+
+  ROOT_PATH = Pathname.new(File.expand_path("../../tmp/app", __FILE__))
+  ASSET_PATH = ROOT_PATH.join("app","assets", "config")
+
+  def setup
+    FileUtils.mkdir_p(ROOT_PATH)
+    Dir.chdir(ROOT_PATH)
+
+    @app = Class.new(Rails::Application)
+    @app.config.eager_load = false
+    @app.config.logger = ActiveSupport::Logger.new("/dev/null")
+
+    FileUtils.mkdir_p(ASSET_PATH)
+    File.open(ASSET_PATH.join("manifest.js"), "w") { |f| f << "" }
+
+    @app.initialize!
+
+    Rails.logger.level = Logger::DEBUG
+  end
+
+  def test_silences_with_default_prefix
+    assert_equal Logger::ERROR, middleware.call("PATH_INFO" => "/assets/stylesheets/application.css")
+  end
+
+  def test_silencess_with_custom_prefix
+    Rails.application.config.assets.prefix = "path/to"
+    assert_equal Logger::ERROR, middleware.call("PATH_INFO" => "/path/to/thing")
+  end
+
+  def test_does_not_silence_without_match
+    assert_equal Logger::DEBUG, middleware.call("PATH_INFO" => "/path/to/thing")
+  end
+
+  private
+
+  def middleware
+    @middleware ||= Sprockets::Rails::QuietAssets.new(->(env) { Rails.logger.level })
+  end
+end

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -384,4 +384,25 @@ class TestRailtie < TestBoot
     assert_equal ["#{ROOT}/app/assets/config", "#{ROOT}/javascripts", "#{ROOT}/stylesheets"],
       env.paths.sort
   end
+
+  def test_quiet_assets_defaults_to_off
+    app.initialize!
+    app.load_tasks
+
+    assert_equal false, app.config.assets.quiet
+    refute app.config.middleware.include?(Sprockets::Rails::QuietAssets)
+  end
+
+  def test_quiet_assets_inserts_middleware
+    app.configure do
+      config.assets.quiet = true
+    end
+    app.initialize!
+    app.load_tasks
+    middleware = app.config.middleware
+
+    assert_equal true, app.config.assets.quiet
+    assert middleware.include?(Sprockets::Rails::QuietAssets)
+    assert middleware.each_cons(2).include?([Sprockets::Rails::QuietAssets, Rails::Rack::Logger])
+  end
 end


### PR DESCRIPTION
@rafaelfranca @josh 

Builds on and finishes what @route started in #338.

Basically a deprecation of the [`quiet_assets`](https://github.com/evrone/quiet_assets/) gem.

Adds the `config.assets.quiet` option. Defaulted to `false` in all cases. When true, it loads a middleware. That middleware looks at the asset prefix path, and if matches will wrap the given request in a `logger.silence { }` call.

I've added to the `README` but I don't know if/where I should document it further.