### PR TITLE
Add a note that SRI only works over HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ javascript_include_tag :application, integrity: true
 # => "<script src="/assets/application.js" integrity="sha256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>"
 ```
 
+Note that sprockets-rails only adds integrity hashes to assets when served over an HTTPS connection.
+
 
 ## Contributing to Sprockets Rails
 


### PR DESCRIPTION
Add a note that the SRI attribute is only applied when the Rails app is served over HTTPS. This is something that tripped me up initially, as browsers treat localhost as a secure origin.

Source: https://github.com/rails/sprockets-rails/commit/fdb0df6b7bf890df3a632e754ec7d4e51688662f