### PR TITLE
Remove requirement of HTTPS for using SRI

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,6 @@ javascript_include_tag :application, integrity: true
 # => "<script src="/assets/application.js" integrity="sha256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs="></script>"
 ```
 
-Note that sprockets-rails only adds integrity hashes to assets when served over an HTTPS connection.
-
 
 ## Contributing to Sprockets Rails
 

--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -178,22 +178,10 @@ module Sprockets
         # doesn't bleed into the tag attributes, but also check its value if
         # it's boolean-ish.
         def compute_integrity?(options)
-          if secure_subresource_integrity_context?
-            case options['integrity']
-            when nil, false, true
-              options.delete('integrity') == true
-            end
-          else
-            options.delete 'integrity'
-            false
+          case options['integrity']
+          when nil, false, true
+            options.delete('integrity') == true
           end
-        end
-
-        # The SRI spec does not require HTTPS, although you're
-        # not benefiting from the extra security without HTTPS.
-        #   https://www.w3.org/TR/SRI/#is-response-eligible-for-integrity-validation
-        def secure_subresource_integrity_context?
-          respond_to?(:request) && self.request
         end
 
         # Enable split asset debugging. Eventually will be deprecated

--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -189,10 +189,11 @@ module Sprockets
           end
         end
 
-        # Only serve integrity metadata for HTTPS requests:
-        #   http://www.w3.org/TR/SRI/#non-secure-contexts-remain-non-secure
+        # The SRI spec does not require HTTPS, although you're
+        # not benefiting from the extra security without HTTPS.
+        #   https://www.w3.org/TR/SRI/#is-response-eligible-for-integrity-validation
         def secure_subresource_integrity_context?
-          respond_to?(:request) && self.request && self.request.ssl?
+          respond_to?(:request) && self.request
         end
 
         # Enable split asset debugging. Eventually will be deprecated

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -205,44 +205,6 @@ class NoHostHelperTest < HelperTest
   end
 end
 
-class NoSSLHelperTest < NoHostHelperTest
-  def setup
-    super
-
-    @view.request = nil
-  end
-
-  def test_javascript_include_tag_integrity
-    assert_dom_equal %(<script src="/javascripts/static.js"></script>),
-      @view.javascript_include_tag("static", integrity: true)
-    assert_dom_equal %(<script src="/javascripts/static.js"></script>),
-      @view.javascript_include_tag("static", integrity: false)
-    assert_dom_equal %(<script src="/javascripts/static.js"></script>),
-      @view.javascript_include_tag("static", integrity: nil)
-
-    assert_dom_equal %(<script src="/javascripts/static.js"></script>),
-      @view.javascript_include_tag("static", integrity: "sha-256-TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs=")
-
-    assert_dom_equal %(<script src="/assets/foo.js"></script>),
-      @view.javascript_include_tag("foo", integrity: true)
-  end
-
-  def test_stylesheet_link_tag_integrity
-    assert_dom_equal %(<link href="/stylesheets/static.css" media="screen" rel="stylesheet" />),
-      @view.stylesheet_link_tag("static", integrity: true)
-    assert_dom_equal %(<link href="/stylesheets/static.css" media="screen" rel="stylesheet" />),
-      @view.stylesheet_link_tag("static", integrity: false)
-    assert_dom_equal %(<link href="/stylesheets/static.css" media="screen" rel="stylesheet" />),
-      @view.stylesheet_link_tag("static", integrity: nil)
-
-    assert_dom_equal %(<link href="/stylesheets/static.css" media="screen" rel="stylesheet" />),
-      @view.stylesheet_link_tag("static", integrity: "sha-256-5YzTQPuOJz/EpeXfN/+v1sxsjAj/dw8q26abiHZM3A4=")
-
-    assert_dom_equal %(<link href="/assets/foo.css" media="screen" rel="stylesheet" />),
-      @view.stylesheet_link_tag("foo", integrity: true)
-  end
-end
-
 class RelativeHostHelperTest < HelperTest
   def setup
     super


### PR DESCRIPTION
The spec has been updated since this code was originally written and this no longer requires a Secure Context: https://www.w3.org/TR/SRI/#is-response-eligible-for-integrity-validation