### PR TITLE
Deprecate asset fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ Each asset task will invoke `assets:environment` first. By default this loads th
 
 Also see [Sprockets::Rails::Task](https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/rails/task.rb) and [Rake::SprocketsTask](https://github.com/rails/sprockets/blob/master/lib/rake/sprocketstask.rb).
 
-
 ### Initializer options
+
+**`config.assets.unknown_asset_fallback`**
+
+When set to a truthy value, the a result will be returned even if the requested asset is not found in the asset pipeline. When set to `false` it will raise an error.
 
 **`config.assets.precompile`**
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Also see [Sprockets::Rails::Task](https://github.com/rails/sprockets-rails/blob/
 
 **`config.assets.unknown_asset_fallback`**
 
-When set to a truthy value, the a result will be returned even if the requested asset is not found in the asset pipeline. When set to `false` it will raise an error.
+When set to a truthy value, a result will be returned even if the requested asset is not found in the asset pipeline. When set to a falsey value it will raise an error when no asset is found in the pipeline. Defaults to `true`.
 
 **`config.assets.precompile`**
 

--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -7,6 +7,7 @@ module Sprockets
   module Rails
     module Helper
       class AssetNotFound < StandardError; end
+
       class AssetNotPrecompiled < StandardError
         include Sprockets::Rails::Utils
         def initialize(source)
@@ -82,8 +83,10 @@ module Sprockets
           raise AssetNotFound, message unless unknown_asset_fallback
 
           if respond_to?(:public_compute_asset_path)
-            message << "The public fallback behavior is being deprecaed and will be removed.\n"
-            message << "pass in `skip_pipeline: true` instead.\n"
+            message << "Falling back to an asset that may be in the public folder.\n"
+            message << "This behavior is deprecated and will be removed.\n"
+            message << "To bypass the asset pipeline and preserve this behavior,\n"
+            message << "use the `skip_pipeline: true` option.\n"
 
             call_stack = respond_to?(:caller_locations) ? caller_locations : caller
             ActiveSupport::Deprecation.warn(message, call_stack)

--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -261,19 +261,6 @@ module Sprockets
             path
           end
         end
-
-      private
-        # Emits a deprecation warning when asset pipeline
-        # is used with an asset that is not part of the pipeline.
-        #
-        # Attempts to determine proper method name based on caller.
-        def deprecate_invalid_asset_lookup(name, call_stack)
-          message =  "The asset #{ name.inspect } you are looking for is not present in the asset pipeline.\n"
-          message << "The public fallback behavior is being deprecated and will be removed.\n"
-          message << "pass in `skip_pipeline: true` instead.\n"
-
-          ActiveSupport::Deprecation.warn(message, call_stack)
-        end
     end
 
     # Use a separate module since Helper is mixed in and we needn't pollute

--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -79,7 +79,7 @@ module Sprockets
         if asset_path = resolve_asset_path(path, debug)
           File.join(assets_prefix || "/", legacy_debug_path(asset_path, debug))
         else
-          message =  "The asset #{ path.inspect } you are looking for is not present in the asset pipeline."
+          message =  "The asset #{ path.inspect } is not present in the asset pipeline."
           raise AssetNotFound, message unless unknown_asset_fallback
 
           if respond_to?(:public_compute_asset_path)

--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -83,7 +83,7 @@ module Sprockets
 
           if respond_to?(:public_compute_asset_path)
             message << "The public fallback behavior is being deprecaed and will be removed.\n"
-            message << "pass in `public_folder: true` instead.\n"
+            message << "pass in `skip_pipeline: true` instead.\n"
 
             call_stack = respond_to?(:caller_locations) ? caller_locations : caller
             ActiveSupport::Deprecation.warn(message, call_stack)
@@ -267,7 +267,7 @@ module Sprockets
         def deprecate_invalid_asset_lookup(name, call_stack)
           message =  "The asset #{ name.inspect } you are looking for is not present in the asset pipeline.\n"
           message << "The public fallback behavior is being deprecated and will be removed.\n"
-          message << "pass in `public_folder: true` instead.\n"
+          message << "pass in `skip_pipeline: true` instead.\n"
 
           ActiveSupport::Deprecation.warn(message, call_stack)
         end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -122,6 +122,7 @@ module Sprockets
     config.assets.cache_limit = 50.megabytes
     config.assets.gzip        = true
     config.assets.check_precompiled_asset = true
+    config.assets.unknown_asset_fallback  = true
 
     config.assets.configure do |env|
       config.assets.paths.each { |path| env.append_path(path) }
@@ -245,7 +246,7 @@ module Sprockets
         self.resolve_assets_with = config.assets.resolve_with
 
         self.check_precompiled_asset = config.assets.check_precompiled_asset
-
+        self.unknown_asset_fallback  = config.assets.unknown_asset_fallback
         # Expose the app precompiled asset check to the view
         self.precompiled_asset_checker = -> logical_path { app.asset_precompiled? logical_path }
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,7 @@ class HelperTest < ActionView::TestCase
     @view.assets_precompile   = %w( manifest.js )
     precompiled_assets = @manifest.find(@view.assets_precompile).map(&:logical_path)
     @view.check_precompiled_asset = true
+    @view.unknown_asset_fallback  = true
     @view.precompiled_asset_checker = -> logical_path { precompiled_assets.include? logical_path }
     @view.request = ActionDispatch::Request.new({
       "rack.url_scheme" => "https"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -829,36 +829,32 @@ end
 
 class DeprecationTest < HelperTest
   def test_deprecations_for_asset_path
-    @view.send(:define_singleton_method, :public_asset_path, -> {})
-    assert_deprecated(/public_asset_path/) do
+    @view.send(:define_singleton_method, :public_compute_asset_path, -> {})
+    assert_deprecated do
       @view.asset_path("does_not_exist.noextension")
     end
   ensure
-    @view.instance_eval('undef :public_asset_path')
+    @view.instance_eval('undef :public_compute_asset_path')
   end
 
   def test_deprecations_for_asset_url
-    @view.send(:define_singleton_method, :public_asset_path, -> {})
-    @view.send(:define_singleton_method, :public_asset_url, -> {})
+    @view.send(:define_singleton_method, :public_compute_asset_path, -> {})
 
-    assert_deprecated(/public_asset_url/) do
+    assert_deprecated do
       @view.asset_url("does_not_exist.noextension")
     end
   ensure
-    @view.instance_eval('undef :public_asset_path')
-    @view.instance_eval('undef :public_asset_url')
+    @view.instance_eval('undef :public_compute_asset_path')
   end
 
   def test_deprecations_for_image_tag
-    @view.send(:define_singleton_method, :public_asset_path, -> {})
-    @view.send(:define_singleton_method, :public_image_tag, -> {})
+    @view.send(:define_singleton_method, :public_compute_asset_path, -> {})
 
-    assert_deprecated(/public_image_tag/) do
+    assert_deprecated do
       @view.image_tag("does_not_exist.noextension")
     end
   ensure
-    @view.instance_eval('undef :public_asset_path')
-    @view.instance_eval('undef :public_image_tag')
+    @view.instance_eval('undef :public_compute_asset_path')
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -827,6 +827,41 @@ class PrecompiledAssetHelperTest < HelperTest
   end
 end
 
+class DeprecationTest < HelperTest
+  def test_deprecations_for_asset_path
+    @view.send(:define_singleton_method, :public_asset_path, -> {})
+    assert_deprecated(/public_asset_path/) do
+      @view.asset_path("does_not_exist.noextension")
+    end
+  ensure
+    @view.instance_eval('undef :public_asset_path')
+  end
+
+  def test_deprecations_for_asset_url
+    @view.send(:define_singleton_method, :public_asset_path, -> {})
+    @view.send(:define_singleton_method, :public_asset_url, -> {})
+
+    assert_deprecated(/public_asset_url/) do
+      @view.asset_url("does_not_exist.noextension")
+    end
+  ensure
+    @view.instance_eval('undef :public_asset_path')
+    @view.instance_eval('undef :public_asset_url')
+  end
+
+  def test_deprecations_for_image_tag
+    @view.send(:define_singleton_method, :public_asset_path, -> {})
+    @view.send(:define_singleton_method, :public_image_tag, -> {})
+
+    assert_deprecated(/public_image_tag/) do
+      @view.image_tag("does_not_exist.noextension")
+    end
+  ensure
+    @view.instance_eval('undef :public_asset_path')
+    @view.instance_eval('undef :public_image_tag')
+  end
+end
+
 class RaiseUnlessPrecompiledAssetDisabledTest < HelperTest
   def test_check_precompiled_asset_enabled
     @view.check_precompiled_asset = true


### PR DESCRIPTION
When an asset isn't found the behavior is to pass the string through. For example a valid asset will return a url from pipeline

```
asset_path("application.js")
# => assets/application-123098udasvi0mnafd.js
```

While if you make a typo, you won't get an error or anything, it just falls through:

```
asset_path("app1icati0n.js")
# => "app1icati0n.js"
```

Hopefully I don't have to elaborate on why this is bad.

This PR is a child PR to one in Rails that will introduce a `public_asset_path` API.

There are valid reasons for not using the asset pipeline, if you have a purely static asset in the public folder or if you want to link to a static URL in your assets somewhere it makes sense to declare that intention. Eventually we will replace the behavior of the deprecation with an exception so people don't lose hours of their to typos.

We only emit the deprecation when a `public_` api is available in Rails. This means that sprockets-rails can still be used in a backwards compatible manner.