### PR TITLE
Add useful message for logger silence error

### DIFF
--- a/lib/sprockets/rails/quiet_assets.rb
+++ b/lib/sprockets/rails/quiet_assets.rb
@@ -1,5 +1,7 @@
 module Sprockets
   module Rails
+    class LoggerSilenceError < StandardError; end
+
     class QuietAssets
       def initialize(app)
         @app = app
@@ -8,11 +10,23 @@ module Sprockets
 
       def call(env)
         if env['PATH_INFO'] =~ @assets_regex
+          raise_logger_silence_error unless ::Rails.logger.respond_to?(:silence)
+
           ::Rails.logger.silence { @app.call(env) }
         else
           @app.call(env)
         end
       end
+
+      private
+        def raise_logger_silence_error
+          error = "You have enabled `config.assets.quiet`, but your `Rails.logger`\n"
+          error << "does not use the `LoggerSilence` module.\n\n"
+          error << "Please use a compatible logger such as `ActiveSupport::Logger`\n"
+          error << "to take advantage of quiet asset logging.\n\n"
+
+          raise LoggerSilenceError, error
+        end
     end
   end
 end

--- a/test/test_quiet_assets.rb
+++ b/test/test_quiet_assets.rb
@@ -43,6 +43,12 @@ class TestQuietAssets < Minitest::Test
     assert_equal Logger::DEBUG, middleware.call("PATH_INFO" => "/path/to/thing")
   end
 
+  def test_logger_does_not_respond_to_silence
+    ::Rails.logger.stub :respond_to?, false do
+      assert_raises(Sprockets::Rails::LoggerSilenceError) { middleware.call("PATH_INFO" => "/assets/stylesheets/application.css") }
+    end
+  end
+
   private
 
   def middleware


### PR DESCRIPTION
The introduction of the quiet assets middleware assumes that `::Rails.logger` responds to `#silence`. For projects using incompatible logger objects, like Ruby's `Logger`, a (potentially confusing) `NoMethodError` is raised in development when `config.assets.quiet` is enabled. 

This change now provides an informative error message to help developers update their configured logger to take advantage of quiet asset logging.

Fixes #376 
