### PR TITLE
Be more specific with required file

### DIFF
--- a/lib/sprockets/rails/context.rb
+++ b/lib/sprockets/rails/context.rb
@@ -1,4 +1,4 @@
-require 'action_view'
+require 'action_view/helpers'
 require 'sprockets'
 
 module Sprockets


### PR DESCRIPTION
This fixes a problem with being unable to load `ActionView::Helpers::AssetUrlHelper` from L7 in some situations

@rafaelfranca 