### PR TITLE
Remove unused development_dependency sass and uglifier

### DIFF
--- a/sprockets-rails.gemspec
+++ b/sprockets-rails.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |s|
   s.add_dependency "activesupport", ">= 4.0"
   s.add_development_dependency "railties", ">= 4.0"
   s.add_development_dependency "rake"
-  s.add_development_dependency "sass"
-  s.add_development_dependency "uglifier"
 
   s.author = "Joshua Peek"
   s.email  = "josh@joshpeek.com"


### PR DESCRIPTION
sass and uglifier are set in sprockets-rails.gemspec as development dependency.
And those look used in test/test_railtie.rb test_compressors
However it is actually not used in the test, and it works without these gems.
So, I think we can remove these development dependencies.

Remove sass and uglifier lines from the gemspec file.

```
$ vi sprockets-rails.gemspec
```

```
$ ruby -v
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-linux]

$ bundle install --path vendor/bundle

$ bundle list
Gems included by the bundle:
  * actionpack (5.1.0.alpha 6e692e6)
  * actionview (5.1.0.alpha 6e692e6)
  * activesupport (5.1.0.alpha 6e692e6)
  * builder (3.2.2)
  * bundler (1.12.5)
  * concurrent-ruby (1.0.2)
  * erubis (2.7.0)
  * i18n (0.7.0)
  * loofah (2.0.3)
  * method_source (0.8.2)
  * mini_portile2 (2.1.0)
  * minitest (5.9.1)
  * nokogiri (1.6.8.1)
  * rack (2.0.1 1482870)
  * rack-test (0.6.3)
  * rails-dom-testing (2.0.1)
  * rails-html-sanitizer (1.0.3)
  * railties (5.1.0.alpha 6e692e6)
  * rake (11.3.0)
  * sprockets (3.7.0 99b3eb2)
  * sprockets-rails (3.2.0)
  * thor (0.19.1)
  * thread_safe (0.3.5)
  * tzinfo (1.2.2)

$ bundle exec rake test
...
152 runs, 752 assertions, 0 failures, 0 errors, 0 skips 
```

Run only target test just in case.

```
$ bundle exec ruby -Ilib test/test_railtie.rb --name test_compressors
...
1 runs, 3 assertions, 0 failures, 0 errors, 0 skips
```
