### PR TITLE
append_assets_path should be called before finisher_hook

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -54,7 +54,7 @@ module Rails
   class Engine < Railtie
     # Skip defining append_assets_path on Rails <= 4.2
     unless initializers.find { |init| init.name == :append_assets_path }
-      initializer :append_assets_path, :group => :all do |app|
+      initializer :append_assets_path, before: :finisher_hook, :group => :all do |app|
         app.config.assets.paths.unshift(*paths["vendor/assets"].existent_directories)
         app.config.assets.paths.unshift(*paths["lib/assets"].existent_directories)
         app.config.assets.paths.unshift(*paths["app/assets"].existent_directories)


### PR DESCRIPTION
Migrating to rails 5 context.
A project includes the refinerycms engine (example project prepared below).
When the project includes the refinerycms than the app assets are not added to Rails.application.assets.paths. From there non of the assets in the app/assets folder could be found.

There is an initializer called append_assets_path that gets called in rails4, in rails 5 without the engine and in rails 5 with the engine. The initializer is there.

But when the engine is present the append_assets_path is called after the finisher_hook initializer. This happens because the initializers are sorted in this way:

```
 def run_initializers(group=:default, *args)
      return if instance_variable_defined?(:@ran)
      initializers.tsort_each do |initializer|
        initializer.run(*args) if initializer.belongs_to?(group)
      end
      @ran = true
    end
```
Here the end result after initializers.tsort_each is
```
...
finisher_hook
...
append_assets_path
```

But i think the correct order should be

```
...
append_assets_path
...
finisher_hook
```
It is important to use the finisher_hook because it moves all the paths from config.assets.paths to env

Look at sprokects-rails-3.2.0/lib/sprockets/railtie.rb
```
config.assets.configure do |env|
  config.assets.paths.each { |path| env.append_path(path) }
end
```

Move information:

Initially  working on issue
https://github.com/refinery/refinerycms/issues/3178
From there created issue
https://github.com/rails/sprockets/issues/458

I have prepared a demo project
https://github.com/thebravoman/sprockets_not_loading_assets
