### PR TITLE
Do not suggest `link_directory` in manifest.js

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -73,9 +73,9 @@ module Sprockets
         "But did not, please create this file and use it to link any assets that need\n" +
         "to be rendered by your app:\n\n" +
         "Example:\n" +
-        "  //= link_tree ../images\n"  +
-        "  //= link_directory ../javascripts .js\n" +
-        "  //= link_directory ../stylesheets .css\n"  +
+        "  //= link application.js\n" +
+        "  //= link application.css\n" +
+        "  //= link_tree ../images\n" +
         "and restart your server"
         super msg
       end


### PR DESCRIPTION
The `link_directory` directive will compile an asset for EVERY file in that directory. To preserve the behavior of Rails 3 we should encourage only generating a minimal subset of assets such as `application.js` and application.css`.