### PR TITLE
Create independent rake task for manifest.js

### DIFF
--- a/lib/sprockets/rails/task.rb
+++ b/lib/sprockets/rails/task.rb
@@ -62,11 +62,17 @@ module Sprockets
             Rake::Task['environment'].invoke
           end
 
-          desc "Compile all the assets named in config.assets.precompile"
-          task :precompile => :environment do
+          desc "Compile all the assets named in manifest.js"
+          task :manifest => :environment do
             with_logger do
               manifest.compile(assets)
             end
+          end
+
+          # This is enhanced for yarn:install and webpacker:compile
+          desc "Compile all the assets on the asset pipeline"
+          task :precompile do
+            Rake::Task['assets:manifest'].invoke
           end
 
           desc "Remove old compiled assets"


### PR DESCRIPTION
to be executed separately from yarn:install and webpacker:compile.

I want to achieve the deployment process as described in https://github.com/rails/rails/pull/28613 but the PR is not approved. Thus I want to have sprockets-only version of `assets:precompile` to avoid duplicated `yarn install` executions.

In addition, considering that railtie and webpacker enhance `assets:precompile` and that now manifest.js is used for `manifest.compile`, I think the task description "Compile all the assets named in config.assets.precompile" is obsolete. So I changed that.

cc/ @dhh