### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1
-  - 2.2.4
-  - 2.3.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - ruby-head
 
 gemfile:
   - Gemfile
@@ -37,6 +39,9 @@ matrix:
       rvm: 2.0.0
     - gemfile: gemfiles/Gemfile.rails-5.0.x.sprockets-4.x
       rvm: 2.1
+  allow_failures:
+    - rvm: ruby-head
+  fast_finish: true
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,14 @@ matrix:
       rvm: 2.0.0
     - gemfile: Gemfile
       rvm: 2.1
+    - gemfile: gemfiles/Gemfile.rails-4.0.x
+      rvm: 2.4.1
+    - gemfile: gemfiles/Gemfile.rails-4.0.x
+      rvm: ruby-head
+    - gemfile: gemfiles/Gemfile.rails-4.1.x
+      rvm: 2.4.1
+    - gemfile: gemfiles/Gemfile.rails-4.1.x
+      rvm: ruby-head
     - gemfile: gemfiles/Gemfile.rails-5.0.x
       rvm: 1.9.3
     - gemfile: gemfiles/Gemfile.rails-5.0.x

--- a/gemfiles/Gemfile.rails-4.2.x
+++ b/gemfiles/Gemfile.rails-4.2.x
@@ -3,3 +3,4 @@ gemspec :path => ".."
 
 gem 'actionpack', '~> 4.2.0'
 gem 'railties', '~> 4.2.0'
+gem 'nokogiri', '< 1.7' if RUBY_VERSION < '2.1.0'

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -80,7 +80,8 @@ class TestRailtie < TestBoot
     assert_equal ROOT, env.root
     assert_equal "", env.version
     assert env.cache
-    assert_equal ["#{ROOT}/app/assets/config"], env.paths
+    assert_includes(env.paths, "#{ROOT}/app/assets/config")
+
     assert_nil env.js_compressor
     assert_nil env.css_compressor
   end
@@ -128,8 +129,9 @@ class TestRailtie < TestBoot
     app.initialize!
 
     assert env = app.assets
-    assert_equal ["#{ROOT}/app/assets/config", "#{ROOT}/javascripts", "#{ROOT}/stylesheets"],
-      env.paths.sort
+    assert_includes(env.paths, "#{ROOT}/javascripts")
+    assert_includes(env.paths, "#{ROOT}/stylesheets")
+    assert_includes(env.paths, "#{ROOT}/app/assets/config")
   end
 
   def test_compressors
@@ -220,8 +222,10 @@ class TestRailtie < TestBoot
     app.initialize!
 
     assert env = app.assets
-    assert_equal ["#{ROOT}/app/assets/config", "#{ROOT}/javascripts", "#{ROOT}/stylesheets"],
-      env.paths.sort
+
+    assert_includes(env.paths, "#{ROOT}/javascripts")
+    assert_includes(env.paths, "#{ROOT}/stylesheets")
+    assert_includes(env.paths, "#{ROOT}/app/assets/config")
   end
 
   def test_environment_is_frozen_if_caching_classes
@@ -381,8 +385,9 @@ class TestRailtie < TestBoot
     assert_kind_of Sprockets::Environment, env
 
     assert_equal ROOT, env.root
-    assert_equal ["#{ROOT}/app/assets/config", "#{ROOT}/javascripts", "#{ROOT}/stylesheets"],
-      env.paths.sort
+    assert_includes(env.paths, "#{ROOT}/javascripts")
+    assert_includes(env.paths, "#{ROOT}/stylesheets")
+    assert_includes(env.paths, "#{ROOT}/app/assets/config")
   end
 
   def test_quiet_assets_defaults_to_off

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -51,6 +51,10 @@ class TestBoot < Minitest::Test
   def test_initialize
     app.initialize!
   end
+
+  def self.test_order
+    :alpha
+  end
 end
 
 class TestRailtie < TestBoot


### PR DESCRIPTION
I updated Rubies to latest version.
I also added ruby-head to Travis as allow_failures.


I think this is useful.
Because we can prepare before next version Ruby 2.5 release.
Though it might not be useful until the actual preview release.
We can support the next version as faster.

We can see this kind of logic in `rails/rails`, `rspec` and `cucumber` and etc.

https://github.com/rails/rails/blob/master/.travis.yml
https://github.com/rspec/rspec-core/blob/master/.travis.yml
https://github.com/cucumber/cucumber-ruby/blob/master/.travis.yml

Is it merge to add it? 

Thanks.
