### PR TITLE
Specify master branch for Travis build status image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,6 @@ Sprockets Rails is released under the [MIT License](MIT-LICENSE).
 
 ## Code Status
 
-* [![Travis CI](https://api.travis-ci.org/rails/sprockets-rails.svg)](http://travis-ci.org/rails/sprockets-rails)
+* [![Travis CI](https://travis-ci.org/rails/sprockets-rails.svg?branch=master)](http://travis-ci.org/rails/sprockets-rails)
 * [![Gem Version](https://badge.fury.io/rb/sprockets-rails.svg)](http://badge.fury.io/rb/sprockets-rails)
 * [![Dependencies](https://gemnasium.com/rails/sprockets-rails.svg)](https://gemnasium.com/rails/sprockets-rails)


### PR DESCRIPTION
I changed build status image URL.
Maybe we want to check build status for only master branch. We do not want to see build status for PR.

I referred `rails/rails` build status.
https://github.com/rails/rails/blob/master/README.md

You can see modified README here.
https://github.com/junaruga/sprockets-rails/blob/feature/readme-badge-master/README.md