### PR TITLE
Fix a test failure for undefined method `split' for nil:NilClass.

### DIFF
--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -282,7 +282,7 @@ class TestRailtie < TestBoot
     assert env = app.assets
     assert_equal "/assets", env.context_class.assets_prefix
     assert_equal true, env.context_class.digest_assets
-    assert_equal nil, env.context_class.config.asset_host
+    assert_nil env.context_class.config.asset_host
   end
 
   def test_manifest_path


### PR DESCRIPTION
I found below test failure in tests.

> https://travis-ci.org/rails/sprockets-rails/jobs/264678491
> Error:
> TestRailtie#test_sprockets_context_helper:
> NoMethodError: undefined method `split' for nil:NilClass

The error was happened for only `$ bundle exec rake test`.


And below cases, when I ran specifying the test file, the error was not happened.

```
$ bundle exec rake test \
  TEST=test/test_railtie.rb \
  TESTOPTS="--name=test_sprockets_context_helper -v"
...
1 runs, 4 assertions, 0 failures, 0 errors, 0 skips
```

```
$ bundle exec rake test \
  TEST=test/test_railtie.rb
...
26 runs, 90 assertions, 4 failures, 0 errors, 0 skips  <- this is another error, as you know. But not this PR's error.
```

Anyway, when I changed `assert_equal nil` to `assert_nil`, it looks ok.


