### PR TITLE
Enable 'debug: true' option on asset tag helpers

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -137,7 +137,7 @@ module Sprockets
         options = sources.extract_options!.stringify_keys
         integrity = compute_integrity?(options)
 
-        if options["debug"] != false && request_debug_assets?
+        if options["debug"] || (request_debug_assets? && options["debug"] != false)
           sources.map { |source|
             if asset = lookup_debug_asset(source, type: :javascript)
               if asset.respond_to?(:to_a)
@@ -166,7 +166,7 @@ module Sprockets
         options = sources.extract_options!.stringify_keys
         integrity = compute_integrity?(options)
 
-        if options["debug"] != false && request_debug_assets?
+        if options["debug"] || (request_debug_assets? && options["debug"] != false)
           sources.map { |source|
             if asset = lookup_debug_asset(source, type: :stylesheet)
               if asset.respond_to?(:to_a)


### PR DESCRIPTION
From [Section 3.3 of the Edge Guides on the Asset Pipeline](http://edgeguides.rubyonrails.org/asset_pipeline.html#turning-debugging-off):

> Debug mode can also be enabled in Rails helper methods:
> 
> ```erb
> <%= stylesheet_link_tag "application", debug: true %>
> <%= javascript_include_tag "application", debug: true %>
> ```
> 
> The `:debug` option is redundant if debug mode is already on.

But per [lines 140 and 169 of `Sprockets::Rails::Helper`](https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/rails/helper.rb#L140):

```ruby
if options["debug"] != false && request_debug_assets?
```

This conditional allows debugging to be explicitly _disabled_ on a tag when `Rails.application.config.assets.debug == true`, but does _not_ allow it to be enabled when the configuration setting is false.

This PR uses the naive solution (simply adding ` || options["debug"]`) rather than performing more extensive refactoring, since comments indicate that this implementation is slated for replacement anyway.