### PR TITLE
Clarify error message when asset not in the asset pipeline.

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -91,7 +91,7 @@ module Sprockets
           end
 
           if respond_to?(:public_compute_asset_path)
-            message << "Falling back to an asset that may be in the public folder.\n"
+            message << "\nFalling back to an asset that may be in the public folder.\n"
             message << "This behavior is deprecated and will be removed.\n"
             message << "To bypass the asset pipeline and preserve this behavior,\n"
             message << "use the `skip_pipeline: true` option.\n"

--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -81,7 +81,14 @@ module Sprockets
           File.join(assets_prefix || "/", legacy_debug_path(asset_path, debug))
         else
           message =  "The asset #{ path.inspect } is not present in the asset pipeline."
-          raise AssetNotFound, message unless unknown_asset_fallback
+
+          unless unknown_asset_fallback
+            message << "\nThe following asset resolver strategies were used: "
+            message << (asset_resolver_strategies.join(', ').presence ||
+              'none (refer to: `config.assets.resolve_with` on https://github.com/rails/sprockets-rails)')
+
+            raise AssetNotFound, message
+          end
 
           if respond_to?(:public_compute_asset_path)
             message << "Falling back to an asset that may be in the public folder.\n"


### PR DESCRIPTION
Ensure people realize when they've configured sprockets to not use any resolvers.

Motivation: I was upgrading a legacy app and the staging configuration resulted in an empty `resolve_with` array (much to my dismay), and it took some digging to figure out the source of the "is not present in the asset pipeline" error. I hope this can save someone some time in the future.