### PR TITLE
Missing new line in error message

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -80,7 +80,7 @@ module Sprockets
         if asset_path = resolve_asset_path(path, debug)
           File.join(assets_prefix || "/", legacy_debug_path(asset_path, debug))
         else
-          message =  "The asset #{ path.inspect } is not present in the asset pipeline."
+          message =  "The asset #{ path.inspect } is not present in the asset pipeline.\n"
           raise AssetNotFound, message unless unknown_asset_fallback
 
           if respond_to?(:public_compute_asset_path)


### PR DESCRIPTION
Without this, the error prints like this:

```
DEPRECATION WARNING: The asset "application.js" is not present in the asset pipeline.Falling back to an asset that may be in the public folder.
This behavior is deprecated and will be removed.
To bypass the asset pipeline and preserve this behavior,
use the `skip_pipeline: true` option.
```