### PR TITLE
fix: make `config.assets.precompile` overridable again

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -103,9 +103,9 @@ module Sprockets
     initializer :set_default_precompile do |app|
       if using_sprockets4?
         raise ManifestNeededError unless ::Rails.root.join("app/assets/config/manifest.js").exist?
-        app.config.assets.precompile += %w( manifest.js )
+        app.config.assets.precompile = %w( manifest.js )
       else
-        app.config.assets.precompile += [LOOSE_APP_ASSETS, /(?:\/|\\|\A)application\.(css|js)$/]
+        app.config.assets.precompile = [LOOSE_APP_ASSETS, /(?:\/|\\|\A)application\.(css|js)$/]
       end
     end
 


### PR DESCRIPTION
In previous versions it was possible to set (instead of extend) the `precompile` array.
This was broken, seemingly by accident, in https://github.com/rails/sprockets-rails/commit/af647983b6fcb265276f184f037ede929ee99bf1

fixes #218
fixes #327
fixes #390