### PR TITLE
describe performance benefits of disabling config.assets.check_precompiled_asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,11 @@ If the resolver list is empty (e.g. if debug is true and compile is false), the 
 
 **`config.assets.check_precompiled_asset`**
 
-When enabled, an exception is raised for missing assets. This option is enabled by default.
+When enabled, an exception is raised for missing assets. This option is enabled
+by default. When `config.assets.compile` is true and asset precompilation is not
+used, this setting causes sprockets to compile all assets on the first request
+for any asset. Therefore, disabling `check_precompiled_asset` can drastically
+reduce the time taken to request the first asset in development.
 
 ## Complementary plugins
 


### PR DESCRIPTION
After hours of debugging long latency on the first call to `ActionView::Helpers::AssetUrlHelper.asset_path` in development, I finally discovered the performance benefits of disabling `config.assets.check_precompiled_asset` via this issue: https://github.com/rails/sprockets-rails/issues/352 this reduced time for the first call to `asset_path` to complete from > 60 seconds to < 1 second on developer machines for our application.

This pull request attempts to improve the documentation for this setting so that people trying to debug similar performance problems will have a clue to try disabling `config.assets.check_precompiled_asset`.