### PR TITLE
Allow using a custom assets configuration manifest

### DIFF
--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -12,6 +12,15 @@ ensure
   $stderr.reopen orig_stderr
 end
 
+def create_config_manifest(dir = "app/assets/config")
+  Dir.chdir(app.root) do
+    FileUtils.mkdir_p(dir)
+    File.open("#{ dir }/manifest.js", "w") do |f|
+      f << ""
+    end
+  end
+end
+
 class TestBoot < Minitest::Test
   include ActiveSupport::Testing::Isolation
 
@@ -39,13 +48,7 @@ class TestBoot < Minitest::Test
     @app.config.active_support.deprecation = :notify
     ActionView::Base # load ActionView
 
-    Dir.chdir(app.root) do
-      dir = "app/assets/config"
-      FileUtils.mkdir_p(dir)
-      File.open("#{ dir }/manifest.js", "w") do |f|
-        f << ""
-      end
-    end
+    create_config_manifest
   end
 
   def test_initialize
@@ -293,6 +296,31 @@ class TestRailtie < TestBoot
     assert_equal "/assets", env.context_class.assets_prefix
     assert_equal true, env.context_class.digest_assets
     assert_nil env.context_class.config.asset_host
+  end
+
+  def test_default_config_manifest_path
+    app.initialize!
+    assert_match %r{app/assets/config.manifest.js$}, app.config.assets.config_manifest
+  end
+
+  def test_custom_config_manifest_path
+    create_config_manifest("my/custom/path")
+    app.configure do
+      config.assets.config_manifest = 'my/custom/path/manifest.js'
+    end
+    app.initialize!
+
+    assert_match %r{my/custom/path/manifest.js$}, app.config.assets.config_manifest
+  end
+
+  def test_config_manifest_raises_when_does_not_exist
+    app.configure do
+      config.assets.config_manifest = 'not/found/manifest.js'
+    end
+
+    assert_raises Sprockets::Railtie::ManifestNeededError do
+      app.initialize!
+    end
   end
 
   def test_manifest_path


### PR DESCRIPTION
Ref https://github.com/rails/sprockets-rails/issues/369

Using Sprockets 4, at the moment, the only allowed path for the newly required configuration manifest is the default one (`app/assets/config/manifest.js`) and there is no way to change it. 

This PR adds a way to change the default location by adding a new `config.assets.config_manifest` option, that could be set like this:

```ruby
config.assets.config_manifest = File.expand_path('my_custom_path/config/manifest.js', __dir__)
```

**Additional context**

In [Solidus](https://github.com/solidusio/solidus), we use a custom dummy app to perform our specs. We need to configure the path with custom locations for the configurations files we use. This PR allows us to set a custom configuration manifest path, otherwise, we would not be able to be compatible with Sprockets 4.  

Here are some relevant parts of our [DummyApp](https://github.com/solidusio/solidus/blob/674d0598c9b3f53a2434f2f0b02f5284481a0b98/core/lib/spree/testing_support/dummy_app.rb#L89-L96), I hope it helps to contextualize our issue.  

And this is the [failed build output](https://circleci.com/api/v1.1/project/github/solidusio/solidus/13827/output/106/0?file=true) (only first lines are relevant) now that sprockets 4 is used.

<hr>

This is my first contribution to this project so feel free to point out if I missed something important or how can I improve the PR. Thanks!