### PR TITLE
Fix Ruby 2.7 deprecation in helper.rb

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -353,7 +353,7 @@ module Sprockets
 
         private
           def find_asset(path, options = {})
-            @env[path, options]
+            @env[path, **options]
           end
 
           def precompiled?(path)


### PR DESCRIPTION
This is a sibling PR to https://github.com/rails/sprockets/pull/660. This needs to be changed to fix sprockets-rails causing a deprecation warning after the sprockets deprecation warning is fixed.

I've tested this on my Rails app and my test suite passes just fine with this change even if the sprockets change isn't present.

Oddly, this may actually be the only change that's necessary. I don't see any deprecation warning anymore with just this PR, regardless of whether the sprockets change is made or not.