### PR TITLE
Don't require ActionView::Base when rake tasks get loaded:

### DIFF
--- a/lib/sprockets/rails/task.rb
+++ b/lib/sprockets/rails/task.rb
@@ -2,7 +2,6 @@ require 'rake'
 require 'rake/sprocketstask'
 require 'sprockets'
 require 'action_view'
-require 'action_view/base'
 
 module Sprockets
   module Rails


### PR DESCRIPTION
Don't require ActionView::Base when rake tasks get loaded:

- ### Problem

  When running any rake command, Sprockets Rails will autoload
  `ActionView::Base` way too early. This creates a broader issue
  which I described in detail in rails/rails#38024

  ### Solution

  This `require` statement was the last attempt to fix a old [issue](https://github.com/rails/rails/issues/9461)
  in 2014. TL;DR on the issue is that assets_prefix would
  get ignored when precompiling assets.

  A lot has change since 2014 in sprockets-rails and after digging
  I can confirm that requiring AV::Base is no longer needed.
  We don't need it to run assets related rake tasks.
  This is thanks thanks of the decoupling between
  `Sprockets::Rails::Context` and `Sprockets::Rails::Helper`
  in https://github.com/rails/sprockets-rails/commit/32a58f54

cc/ @rafaelfranca 