### PR TITLE
Don't find all precompiled assets to check if one only is precompiled

### DIFF
--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -32,14 +32,7 @@ module Rails
     # Called from asset helpers to alert you if you reference an asset URL that
     # isn't precompiled and hence won't be available in production.
     def asset_precompiled?(logical_path)
-      if precompiled_assets.include?(logical_path)
-        true
-      elsif !config.cache_classes
-        # Check to see if precompile list has been updated
-        precompiled_assets(true).include?(logical_path)
-      else
-        false
-      end
+      assets_manifest.find(logical_path).any?
     end
 
     # Lazy-load the precompile list so we don't cause asset compilation at app


### PR DESCRIPTION
**Problem:**
After upgrading sprockets up to v4 we found that some of our pages load too slow (~20 sec) what was not in the previous version

**PR description:**
It happened because we didn't include the file extension explicitly to an asset path (ex. 'my_path/asset')
In this case, the gem tries to find all precompiled assets and then cache them but it looks like it does not work in my case, so the result I have is the gem tries to find assets on each request (~1250 assets).
I changed this behavior to check if one asset only