### PR TITLE
A May of WTFs: Raise exception for assets declared without extension

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -321,6 +321,8 @@ module Sprockets
         end
 
         def asset_path(path, digest, allow_non_precompiled = false)
+          raise ArgumentError, "asset #{path} should be declared with a filename extension" if File.extname(path).blank?
+
           # Digests enabled? Do the work to calculate the full asset path.
           if digest
             digest_path path, allow_non_precompiled

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -851,6 +851,14 @@ class AssetUrlHelperLinksTarget < HelperTest
     assert_kind_of Sprockets::CachedEnvironment, env
     assert @view.assets_environment.equal?(env), "view didn't return the same cached instance"
   end
+
+  def test_environment_asset_path_without_extension
+    @view.resolve_assets_with = [ :environment ]
+
+    assert_raises(Sprockets::ArgumentError) do
+      @view.asset_path("logo")
+    end
+  end
 end
 
 class PrecompiledAssetHelperTest < HelperTest


### PR DESCRIPTION
Basically, it is possible to use `<%= image_tag('logo') %>` on development without any issues, but in production this always break because the file is not found without its extension. 

This has also been reported on: https://github.com/rails/sprockets-rails/issues/403, https://github.com/rails/sprockets-rails/issues/305 and https://discuss.rubyonrails.org/t/rails-6-0-2-image-tag-logo-works-in-development-but-crashes-in-production/74901/7


I tried to add the least amount of code to "fix" the problem. 

Let me know what you think.