### PR TITLE
Allow age to be altered in assets:clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Deployment task that compiles any assets listed in `config.assets.precompile` to
 
 **`rake assets:clean`**
 
-Only removes old assets (keeps the most recent 3 copies) from `public/assets`. Useful when doing rolling deploys that may still be serving old assets while the new ones are being compiled.
+Only removes old assets (by default keeps the most recent 3 copies and files created within 3600 ) from `public/assets`. Useful when doing rolling deploys that may still be serving old assets while the new ones are being compiled.  Use `rake assets:clean[3,3600]` to keep the last 3 assets or created within the last hour or `rake assets:clean[1,0]` to keep only the most recent old assets.  This never cleans up the currently used assets.
 
 **`rake assets:clobber`**
 

--- a/lib/sprockets/rails/task.rb
+++ b/lib/sprockets/rails/task.rb
@@ -68,10 +68,18 @@ module Sprockets
             end
           end
 
-          desc "Remove old compiled assets"
-          task :clean, [:keep] => :environment do |t, args|
+          desc "Remove old compiled assets.  Arguments\nkeep: minimum previous copies to keep\nage: all assets with age less than this will be kept"
+          task :clean, [:keep, :age] => :environment do |_t, args|
             with_logger do
-              manifest.clean(Integer(args.keep || self.keep))
+              age =
+                if args.age
+                  args.age
+                elsif respond_to?(:age)
+                  age
+                else
+                  3600
+                end
+              manifest.clean(Integer(args.keep || keep), Integer(age))
             end
           end
 

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -114,6 +114,8 @@ class TestTask < Minitest::Test
     FileUtils.cp(path, new_path)
 
     assert File.exist?(new_path)
+    mtime = Time.now - 3601
+    File.utime(mtime, mtime, new_path.to_s)
     digest_path = @assets['foo-modified.js'].digest_path
 
     @rake['assets:precompile'].invoke
@@ -135,7 +137,7 @@ class TestTask < Minitest::Test
 
     @rake['assets:clean'].invoke(0)
     assert File.exist?("#{@dir}/#{digest_path}")
-    # refute File.exist?("#{@dir}/#{old_digest_path}")
+    refute File.exist?("#{@dir}/#{old_digest_path}")
   ensure
     FileUtils.rm(new_path) if new_path
   end


### PR DESCRIPTION
Before assets:clean would leave assets with an
mtime less than 3600 seconds ago.

I've requested `age` to be added to the Rake::SprocketsTask in https://github.com/rails/sprockets/pull/677/