### PR TITLE
Docs: Customization example: log_level, single task

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ Each asset task will invoke `assets:environment` first. By default this loads th
 
 Also see [Sprockets::Rails::Task](https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/rails/task.rb) and [Rake::SprocketsTask](https://github.com/rails/sprockets/blob/master/lib/rake/sprocketstask.rb).
 
+##### Example: Customizing the log_level of a single task
+
+After `Rails.application.load_tasks` has happened, it's necessary to `clear` existing tasks before re-generating them.
+
+```
+Rake::Task['assets:precompile'].clear
+Rake::SprocketsTask.new do |t|
+  t.log_level = ::Logger::WARN # Default is INFO
+end
+```
+
 ### Initializer options
 
 **`config.assets.unknown_asset_fallback`**


### PR DESCRIPTION
Is it useful to have another example of customization here? `log_level` is a pretty common thing to configure, I imagine.

It seems that `Rake::SprocketsTask.new` is slightly easier to use than `Sprockets::Rails::Task.new`, but also maybe I'm doing something completely wrong. I mean, the chances I'm doing something wrong are actually quite high 😅 