### PR TITLE
Raise the error that includes an error message

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -369,7 +369,7 @@ module Sprockets
           end
 
           def raise_unless_precompiled_asset(path)
-            raise Helper::AssetNotPrecompiled.new(path) if @check_precompiled_asset && !precompiled?(path)
+            raise Helper::AssetNotPrecompiledError.new(path) if @check_precompiled_asset && !precompiled?(path)
           end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -880,8 +880,16 @@ class PrecompiledAssetHelperTest < HelperTest
     @bundle_js_name = '/assets/bundle.js'
   end
 
+  # both subclass and more specific error are supported due to
+  # https://github.com/rails/sprockets-rails/pull/414/commits/760a805a9f56d3df0d4b83bd4a5a6476eb3aeb29
   def test_javascript_precompile
     assert_raises(Sprockets::Rails::Helper::AssetNotPrecompiled) do
+      @view.javascript_include_tag("not_precompiled")
+    end
+  end
+
+  def test_javascript_precompile_thows_the_descriptive_error
+    assert_raises(Sprockets::Rails::Helper::AssetNotPrecompiledError) do
       @view.javascript_include_tag("not_precompiled")
     end
   end


### PR DESCRIPTION
Because of the change in https://github.com/rails/sprockets-rails/pull/414, [this line](https://github.com/rails/sprockets-rails/blob/master/lib/sprockets/rails/helper.rb#L372) now raises an error with no helpful message on what you should do to fix it:

```
SessionsControllerTest#test_auth_for_invited_user:
ActionView::Template::Error: owner-banner.png
    /Users/alex/.rvm/gems/ruby-2.7.2/gems/sprockets-rails-3.2.2/lib/sprockets/rails/helper.rb:372:in `raise_unless_precompiled_asset'
```

Instead, we should raise the new error class added in https://github.com/rails/sprockets-rails/pull/414

This would be a breaking change if you had code that looks like this:

```ruby
    begin
      @view.javascript_include_tag("not_precompiled")
    rescue StandardError => e
      puts "error" if e.class == Sprockets::Rails::Helper::AssetNotPrecompiled
    end
```

But that's not very good code. A more normal rescue statement still works fine:

```ruby
    begin
      @view.javascript_include_tag("not_precompiled")
    rescue Sprockets::Rails::Helper::AssetNotPrecompiled => e
      puts "error"
    end
```

cc @schneems 