### PR TITLE
Process source mapping URLs be set by transpilers

### DIFF
--- a/lib/sprockets/rails/sourcemapping_url_processor.rb
+++ b/lib/sprockets/rails/sourcemapping_url_processor.rb
@@ -5,12 +5,14 @@ module Sprockets
       REGEX = /\/\/# sourceMappingURL=(.*\.map)/
 
       def self.call(input)
-        context = input[:environment].context_class.new(input)
+        env     = input[:environment]
+        context = env.context_class.new(input)
         data    = input[:data].gsub(REGEX) do |_match|
           ensure_file_is_present = context.resolve($1)
           "//# sourceMappingURL=#{context.asset_path($1)}\n//!\n"
         rescue Sprockets::FileNotFound
-          # Remove source mapping when the target cannot be found
+          env.logger.warn "Removed sourceMappingURL comment for missing asset '#{$1}' from #{input[:filename]}"
+          nil
         end
 
         { data: data }

--- a/lib/sprockets/rails/sourcemapping_url_processor.rb
+++ b/lib/sprockets/rails/sourcemapping_url_processor.rb
@@ -1,0 +1,19 @@
+module Sprockets
+  module Rails
+    # Rewrites source mapping urls with the digested paths and protect against semicolon appending with a dummy comment line
+    class SourcemappingUrlProcessor
+      REGEX = /\/\/# sourceMappingURL=(.*\.map)/
+
+      def self.call(input)
+        context = input[:environment].context_class.new(input)
+        data    = input[:data].gsub(REGEX) do |_match|
+          "//# sourceMappingURL=#{context.asset_path($1)}\n//!\n"
+        end
+      rescue Sprockets::FileNotFound
+        # Remove source mapping when the target cannot be found
+
+        { data: data }
+      end
+    end
+  end
+end

--- a/lib/sprockets/rails/sourcemapping_url_processor.rb
+++ b/lib/sprockets/rails/sourcemapping_url_processor.rb
@@ -8,9 +8,9 @@ module Sprockets
         context = input[:environment].context_class.new(input)
         data    = input[:data].gsub(REGEX) do |_match|
           "//# sourceMappingURL=#{context.asset_path($1)}\n//!\n"
+        rescue Sprockets::FileNotFound
+          # Remove source mapping when the target cannot be found
         end
-      rescue Sprockets::FileNotFound
-        # Remove source mapping when the target cannot be found
 
         { data: data }
       end

--- a/lib/sprockets/rails/sourcemapping_url_processor.rb
+++ b/lib/sprockets/rails/sourcemapping_url_processor.rb
@@ -7,6 +7,7 @@ module Sprockets
       def self.call(input)
         context = input[:environment].context_class.new(input)
         data    = input[:data].gsub(REGEX) do |_match|
+          ensure_file_is_present = context.resolve($1)
           "//# sourceMappingURL=#{context.asset_path($1)}\n//!\n"
         rescue Sprockets::FileNotFound
           # Remove source mapping when the target cannot be found

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -6,6 +6,7 @@ require 'active_support/core_ext/numeric/bytes'
 require 'sprockets'
 
 require 'sprockets/rails/asset_url_processor'
+require 'sprockets/rails/sourcemap_url_processor'
 require 'sprockets/rails/context'
 require 'sprockets/rails/helper'
 require 'sprockets/rails/quiet_assets'
@@ -120,6 +121,10 @@ module Sprockets
 
     initializer :asset_url_processor do |app|
       Sprockets.register_postprocessor "text/css", ::Sprockets::Rails::AssetUrlProcessor
+    end
+
+    initializer :asset_sourcemap_url_processor do |app|
+      Sprockets.register_postprocessor "application/javascript", ::Sprockets::Rails::SourcemappingUrlProcessor
     end
 
     config.assets.version     = ""

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -6,7 +6,7 @@ require 'active_support/core_ext/numeric/bytes'
 require 'sprockets'
 
 require 'sprockets/rails/asset_url_processor'
-require 'sprockets/rails/sourcemap_url_processor'
+require 'sprockets/rails/sourcemapping_url_processor'
 require 'sprockets/rails/context'
 require 'sprockets/rails/helper'
 require 'sprockets/rails/quiet_assets'

--- a/test/test_sourcemapping_url_processor.rb
+++ b/test/test_sourcemapping_url_processor.rb
@@ -1,0 +1,38 @@
+require 'minitest/autorun'
+require 'sprockets/railtie'
+
+
+Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
+class TestSourceMappingUrlProcessor < Minitest::Test
+  def setup
+    @env = Sprockets::Environment.new
+  end
+
+  def test_successful
+    @env.context_class.class_eval do
+      def resolve(path, **kargs)
+        "/yes"
+      end
+
+      def asset_path(path, options = {})
+        'mapped-HEXGOESHERE.js.map'
+      end
+    end
+
+    input = { environment: @env, data: "var mapped;\n//# sourceMappingURL=mapped.js.map", filename: 'mapped.js', metadata: {} }
+    output = Sprockets::Rails::SourcemappingUrlProcessor.call(input)
+    assert_equal({ data: "var mapped;\n//# sourceMappingURL=mapped-HEXGOESHERE.js.map\n//!\n" }, output)
+  end
+
+  def test_missing
+    @env.context_class.class_eval do
+      def resolve(path, **kargs)
+        raise Sprockets::FileNotFound
+      end
+    end
+
+    input = { environment: @env, data: "var mapped;\n//# sourceMappingURL=mappedNOT.js.map", filename: 'mapped.js', metadata: {} }
+    output = Sprockets::Rails::SourcemappingUrlProcessor.call(input)
+    assert_equal({ data: "var mapped;\n" }, output)
+  end
+end


### PR DESCRIPTION
If you prepare a JavaScript file by a bundler that adds a sourceMappingURL comment line as the last in the file, Sprockets will append a semicolon to this comment, thus breaking the URL reference.

The sourceMappingURL will also reference a file that has not been digested yet.

This PR fixes both issues.