### PR TITLE
expose dependencies from AssetUrlProcessor

### DIFF
--- a/lib/sprockets/rails/asset_url_processor.rb
+++ b/lib/sprockets/rails/asset_url_processor.rb
@@ -8,7 +8,7 @@ module Sprockets
         context = input[:environment].context_class.new(input)
         data    = input[:data].gsub(REGEX) { |_match| "url(#{context.asset_path($1)})" }
 
-        { data: data }
+        context.metadata.merge(data: data)
       end
     end
   end

--- a/test/test_asset_url_processor.rb
+++ b/test/test_asset_url_processor.rb
@@ -4,36 +4,48 @@ require 'sprockets/railtie'
 
 Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
 class TestAssetUrlProcessor < Minitest::Test
+  FIXTURES_PATH = File.expand_path("../fixtures", __FILE__)
+
   def setup
     @env = Sprockets::Environment.new
+    @env.append_path FIXTURES_PATH
     @env.context_class.class_eval do
-      def asset_path(path, options = {})
-        'image-hexcodegoeshere.png'
-      end
+      include ::Sprockets::Rails::Context
     end
+    @env.context_class.digest_assets = true
+
+    @logo_digest = @env["logo.png"].etag
+    @logo_uri    = @env["logo.png"].uri
   end
 
   def test_basic
-    input = { environment: @env, data: 'background: url(image.png);', filename: 'url2.css', metadata: {} }
+    input = { environment: @env, data: 'background: url(logo.png);', filename: 'url2.css', metadata: {} }
     output = Sprockets::Rails::AssetUrlProcessor.call(input)
-    assert_equal({ data: "background: url(image-hexcodegoeshere.png);" }, output)
+    assert_equal("background: url(/logo-#{@logo_digest}.png);", output[:data])
   end
 
   def test_spaces
-    input = { environment: @env, data: 'background: url( image.png );', filename: 'url2.css', metadata: {} }
+    input = { environment: @env, data: 'background: url( logo.png );', filename: 'url2.css', metadata: {} }
     output = Sprockets::Rails::AssetUrlProcessor.call(input)
-    assert_equal({ data: "background: url(image-hexcodegoeshere.png);" }, output)
+    assert_equal("background: url(/logo-#{@logo_digest}.png);", output[:data])
   end
 
   def test_single_quote
-    input = { environment: @env, data: "background: url('image.png');", filename: 'url2.css', metadata: {} }
+    input = { environment: @env, data: "background: url('logo.png');", filename: 'url2.css', metadata: {} }
     output = Sprockets::Rails::AssetUrlProcessor.call(input)
-    assert_equal({ data: "background: url(image-hexcodegoeshere.png);" }, output)
+    assert_equal("background: url(/logo-#{@logo_digest}.png);", output[:data])
   end
 
   def test_double_quote
-    input = { environment: @env, data: 'background: url("image.png");', filename: 'url2.css', metadata: {} }
+    input = { environment: @env, data: 'background: url("logo.png");', filename: 'url2.css', metadata: {} }
     output = Sprockets::Rails::AssetUrlProcessor.call(input)
-    assert_equal({ data: "background: url(image-hexcodegoeshere.png);" }, output)
+    assert_equal("background: url(/logo-#{@logo_digest}.png);", output[:data])
+  end
+
+  def test_dependencies_are_tracked
+    input = { environment: @env, data: 'background: url(logo.png);', filename: 'url2.css', metadata: {} }
+    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    assert_equal(1, output[:links].size)
+    assert_equal(@logo_uri, output[:links].first)
   end
 end


### PR DESCRIPTION
The newly added AssetUrlProcessor hides tracked dependencies. This can cause referenced digested assets to be excluded from the final output during `assets:precompile`.

This PR unhides those dependencies so all referenced assets are output to `public/assets/` properly.