### PR TITLE
Strip away the relative path

### DIFF
--- a/lib/sprockets/rails/asset_url_processor.rb
+++ b/lib/sprockets/rails/asset_url_processor.rb
@@ -2,11 +2,13 @@ module Sprockets
   module Rails
     # Rewrites urls in CSS files with the digested paths
     class AssetUrlProcessor
-      REGEX = /url\(\s*["']?(?!(?:\#|data|http))([^"'\s)]+)\s*["']?\)/
-
+      REGEX = /url\(\s*["']?(?!(?:\#|data|http))(?<relativeToCurrentDir>.\/)?(?<path>[^"'\s)]+)\s*["']?\)/
       def self.call(input)
         context = input[:environment].context_class.new(input)
-        data    = input[:data].gsub(REGEX) { |_match| "url(#{context.asset_path($1)})" }
+        data    = input[:data].gsub(REGEX) do |_match|
+          path = Regexp.last_match[:path]
+          "url(#{context.asset_path(path)})"
+        end
 
         context.metadata.merge(data: data)
       end

--- a/test/test_asset_url_processor.rb
+++ b/test/test_asset_url_processor.rb
@@ -48,4 +48,17 @@ class TestAssetUrlProcessor < Minitest::Test
     assert_equal(1, output[:links].size)
     assert_equal(@logo_uri, output[:links].first)
   end
+
+  def test_relative
+    input = { environment: @env, data: 'background: url(./logo.png);', filename: 'url2.css', metadata: {} }
+    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    assert_equal("background: url(/logo-#{@logo_digest}.png);", output[:data])
+  end
+
+  def test_subdirectory
+    input = { environment: @env, data: "background: url('jquery/jquery.js');", filename: 'url2.css', metadata: {} }
+    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    jquery_digest = 'c6910e1db4a5ed4905be728ab786471e81565f4a9d544734b199f3790de9f9a3'
+    assert_equal("background: url(/jquery/jquery-#{jquery_digest}.js);", output[:data])
+  end
 end


### PR DESCRIPTION
Fixes #478

Previously having this css:
```
src: url(./fontawesome/fa-brands-400.eot);
```

would be transformed into:
```
src: url(/./fontawesome/fa-brands-400.eot);
```

This strips off the unnecessary `./` so it will be:
```
src: url(/fontawesome/fa-brands-400.eot);
```