### PR TITLE
Only process sourceMappingURLs for files, not paths

### DIFF
--- a/lib/sprockets/rails/sourcemapping_url_processor.rb
+++ b/lib/sprockets/rails/sourcemapping_url_processor.rb
@@ -2,7 +2,7 @@ module Sprockets
   module Rails
     # Rewrites source mapping urls with the digested paths and protect against semicolon appending with a dummy comment line
     class SourcemappingUrlProcessor
-      REGEX = /\/\/# sourceMappingURL=(.*\.map)/
+      REGEX = /\/\/# sourceMappingURL=([^\/]+\.map)/
 
       def self.call(input)
         env     = input[:environment]

--- a/test/test_sourcemapping_url_processor.rb
+++ b/test/test_sourcemapping_url_processor.rb
@@ -24,6 +24,16 @@ class TestSourceMappingUrlProcessor < Minitest::Test
     assert_equal({ data: "var mapped;\n//# sourceMappingURL=mapped-HEXGOESHERE.js.map\n//!\n" }, output)
   end
 
+  def test_prevent_recursion
+    input = { environment: @env, data: "var mapped;\n//# sourceMappingURL=/assets/mapped.js.map", filename: 'mapped.js', metadata: {} }
+    output = Sprockets::Rails::SourcemappingUrlProcessor.call(input)
+    assert_equal({ data: "var mapped;\n//# sourceMappingURL=/assets/mapped.js.map" }, output)
+
+    input = { environment: @env, data: "var mapped;\n//# sourceMappingURL=https://cdn.example.com/assets/mapped.js.map", filename: 'mapped.js', metadata: {} }
+    output = Sprockets::Rails::SourcemappingUrlProcessor.call(input)
+    assert_equal({ data: "var mapped;\n//# sourceMappingURL=https://cdn.example.com/assets/mapped.js.map" }, output)
+  end
+
   def test_missing
     @env.context_class.class_eval do
       def resolve(path, **kargs)


### PR DESCRIPTION
This will prevent the recursion issue noticed in #481.