### PR TITLE
Fix protocol relative URLs amended accidentally

### DIFF
--- a/lib/sprockets/rails/asset_url_processor.rb
+++ b/lib/sprockets/rails/asset_url_processor.rb
@@ -2,7 +2,7 @@ module Sprockets
   module Rails
     # Rewrites urls in CSS files with the digested paths
     class AssetUrlProcessor
-      REGEX = /url\(\s*["']?(?!(?:\#|data|http))(?<relativeToCurrentDir>.\/)?(?<path>[^"'\s)]+)\s*["']?\)/
+      REGEX = /url\(\s*["']?(?!(?:\#|data|http))(?<relativeToCurrentDir>\.\/)?(?<path>[^"'\s)]+)\s*["']?\)/
       def self.call(input)
         context = input[:environment].context_class.new(input)
         data    = input[:data].gsub(REGEX) do |_match|

--- a/test/test_asset_url_processor.rb
+++ b/test/test_asset_url_processor.rb
@@ -61,4 +61,10 @@ class TestAssetUrlProcessor < Minitest::Test
     jquery_digest = 'c6910e1db4a5ed4905be728ab786471e81565f4a9d544734b199f3790de9f9a3'
     assert_equal("background: url(/jquery/jquery-#{jquery_digest}.js);", output[:data])
   end
+
+  def test_protocol_relative_paths
+    input = { environment: @env, data: "background: url(//assets.example.com/assets/fontawesome-webfont-82ff0fe46a6f60e0ab3c4a9891a0ae0a1f7b7e84c625f55358379177a2dcb202.eot);", filename: 'url2.css', metadata: {} }
+    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    assert_equal("background: url(//assets.example.com/assets/fontawesome-webfont-82ff0fe46a6f60e0ab3c4a9891a0ae0a1f7b7e84c625f55358379177a2dcb202.eot);", output[:data])
+  end
 end


### PR DESCRIPTION
Issue:

With source file like below and asset host as `//assets.example.com`
```css
@font-face {
  src: url('<%= font_path('fontawesome-webfont.eot') %>');
}
```

would produce
```css
@font-face {
  src:url(//assets.example.com/assets.example.com/assets/fontawesome-webfont-82ff0fe46a6f60e0ab3c4a9891a0ae0a1f7b7e84c625f55358379177a2dcb202.eot)
}
```