### PR TITLE
Add `assets.resolve_assets_in_css_urls` configuration option to allow disabling `AssetUrlProcessor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ config.assets.configure do |env|
 end
 ```
 
+**`config.assets.resolve_assets_in_css_urls`**
+
+When this option is enabled, sprockets-rails will register a CSS postprocessor to resolve assets referenced in [`url()`](https://developer.mozilla.org/en-US/docs/Web/CSS/url()) function calls and replace them with the digested paths. Defaults to `true`.
+
 **`config.assets.resolve_with`**
 
 A list of `:environment` and `:manifest` symbols that defines the order that

--- a/lib/sprockets/rails/asset_url_processor.rb
+++ b/lib/sprockets/rails/asset_url_processor.rb
@@ -1,6 +1,6 @@
 module Sprockets
   module Rails
-    # Rewrites urls in CSS files with the digested paths
+    # Resolve assets referenced in CSS `url()` calls and replace them with the digested paths
     class AssetUrlProcessor
       REGEX = /url\(\s*["']?(?!(?:\#|data|http))(?<relativeToCurrentDir>\.\/)?(?<path>[^"'\s)]+)\s*["']?\)/
       def self.call(input)

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -97,13 +97,13 @@ module Sprockets
     end
 
     config.assets = OrderedOptions.new
-    config.assets._blocks          = []
-    config.assets.paths            = []
-    config.assets.precompile       = []
-    config.assets.prefix           = "/assets"
-    config.assets.manifest         = nil
-    config.assets.quiet            = false
-    config.assets.rewrite_css_urls = true
+    config.assets._blocks                    = []
+    config.assets.paths                      = []
+    config.assets.precompile                 = []
+    config.assets.prefix                     = "/assets"
+    config.assets.manifest                   = nil
+    config.assets.quiet                      = false
+    config.assets.resolve_assets_in_css_urls = true
 
     initializer :set_default_precompile do |app|
       if using_sprockets4?
@@ -121,7 +121,7 @@ module Sprockets
     end
 
     initializer :asset_url_processor do |app|
-      if app.config.assets.rewrite_css_urls
+      if app.config.assets.resolve_assets_in_css_urls
         Sprockets.register_postprocessor "text/css", ::Sprockets::Rails::AssetUrlProcessor
       end
     end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -97,12 +97,13 @@ module Sprockets
     end
 
     config.assets = OrderedOptions.new
-    config.assets._blocks     = []
-    config.assets.paths       = []
-    config.assets.precompile  = []
-    config.assets.prefix      = "/assets"
-    config.assets.manifest    = nil
-    config.assets.quiet       = false
+    config.assets._blocks          = []
+    config.assets.paths            = []
+    config.assets.precompile       = []
+    config.assets.prefix           = "/assets"
+    config.assets.manifest         = nil
+    config.assets.quiet            = false
+    config.assets.rewrite_css_urls = true
 
     initializer :set_default_precompile do |app|
       if using_sprockets4?
@@ -120,7 +121,9 @@ module Sprockets
     end
 
     initializer :asset_url_processor do |app|
-      Sprockets.register_postprocessor "text/css", ::Sprockets::Rails::AssetUrlProcessor
+      if app.config.assets.rewrite_css_urls
+        Sprockets.register_postprocessor "text/css", ::Sprockets::Rails::AssetUrlProcessor
+      end
     end
 
     initializer :asset_sourcemap_url_processor do |app|

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -423,20 +423,20 @@ class TestRailtie < TestBoot
     assert middleware.each_cons(2).include?([Sprockets::Rails::QuietAssets, Rails::Rack::Logger])
   end
 
-  def test_rewrite_css_urls_defaults_to_true
+  def test_resolve_assets_in_css_urls_defaults_to_true
     app.initialize!
 
-    assert_equal true, app.config.assets.rewrite_css_urls
+    assert_equal true, app.config.assets.resolve_assets_in_css_urls
     assert_includes Sprockets.postprocessors['text/css'], Sprockets::Rails::AssetUrlProcessor
   end
 
-  def test_rewrite_css_urls_when_false_avoids_registering_postprocessor
+  def test_resolve_assets_in_css_urls_when_false_avoids_registering_postprocessor
     app.configure do
-      config.assets.rewrite_css_urls = false
+      config.assets.resolve_assets_in_css_urls = false
     end
     app.initialize!
 
-    assert_equal false, app.config.assets.rewrite_css_urls
+    assert_equal false, app.config.assets.resolve_assets_in_css_urls
     refute_includes Sprockets.postprocessors['text/css'], Sprockets::Rails::AssetUrlProcessor
   end
 

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -423,6 +423,23 @@ class TestRailtie < TestBoot
     assert middleware.each_cons(2).include?([Sprockets::Rails::QuietAssets, Rails::Rack::Logger])
   end
 
+  def test_rewrite_css_urls_defaults_to_true
+    app.initialize!
+
+    assert_equal true, app.config.assets.rewrite_css_urls
+    assert_includes Sprockets.postprocessors['text/css'], Sprockets::Rails::AssetUrlProcessor
+  end
+
+  def test_rewrite_css_urls_when_false_avoids_registering_postprocessor
+    app.configure do
+      config.assets.rewrite_css_urls = false
+    end
+    app.initialize!
+
+    assert_equal false, app.config.assets.rewrite_css_urls
+    refute_includes Sprockets.postprocessors['text/css'], Sprockets::Rails::AssetUrlProcessor
+  end
+
   private
     def action_view
       ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)


### PR DESCRIPTION
As reported in https://github.com/rails/sprockets-rails/issues/478 / https://github.com/rails/sprockets-rails/issues/486, the introduction of the `AssetUrlProcessor` in https://github.com/rails/sprockets-rails/pull/476 broke some folks' CSS assets when they upgraded beyond sprockets-rails v3.2.2, but it was not released in a new major version.

~To remedy this, let's make `AssetUrlProcessor` be opt-in for now with the plan to change it to opt-out in the next major version. In this PR, I'm proposing the addition of a new `assets.rewrite_css_urls` configuration option to control whether or not `AssetUrlProcessor` is registered. We can default it to `false` in sprockets-rails v3.x and change the default to `true` in v4.0.~
Per https://github.com/rails/sprockets-rails/pull/489#issuecomment-988582781, we'll roll forward with defaulting `AssetUrlProcessor` to enabled, but it can be disabled by setting a new `assets.resolve_assets_in_css_urls` configuration option to `false`.