### PR TITLE
Link to sprockets repository from README for convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sprockets Rails
 
-Provides Sprockets implementation for Rails 4.x (and beyond) Asset Pipeline.
+Provides [Sprockets](https://github.com/rails/sprockets) implementation for Rails 4.x (and beyond) Asset Pipeline.
 
 
 ## Installation


### PR DESCRIPTION
Let's link directly to the sprockets repository where it is referenced at the beginning of the README so that folks can easily follow the link to learn more about the general sprockets gem.