### PR TITLE
Rename `AssetUrlProcessor` to `CssAssetUrlProcessor`

### DIFF
--- a/lib/sprockets/rails/css_asset_url_processor.rb
+++ b/lib/sprockets/rails/css_asset_url_processor.rb
@@ -1,7 +1,7 @@
 module Sprockets
   module Rails
     # Resolve assets referenced in CSS `url()` calls and replace them with the digested paths
-    class AssetUrlProcessor
+    class CssAssetUrlProcessor
       REGEX = /url\(\s*["']?(?!(?:\#|data|http))(?<relativeToCurrentDir>\.\/)?(?<path>[^"'\s)]+)\s*["']?\)/
       def self.call(input)
         context = input[:environment].context_class.new(input)

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -5,7 +5,7 @@ require 'active_support/core_ext/module/remove_method'
 require 'active_support/core_ext/numeric/bytes'
 require 'sprockets'
 
-require 'sprockets/rails/asset_url_processor'
+require 'sprockets/rails/css_asset_url_processor'
 require 'sprockets/rails/sourcemapping_url_processor'
 require 'sprockets/rails/context'
 require 'sprockets/rails/helper'
@@ -120,9 +120,9 @@ module Sprockets
       end
     end
 
-    initializer :asset_url_processor do |app|
+    initializer :css_asset_url_processor do |app|
       if app.config.assets.resolve_assets_in_css_urls
-        Sprockets.register_postprocessor "text/css", ::Sprockets::Rails::AssetUrlProcessor
+        Sprockets.register_postprocessor "text/css", ::Sprockets::Rails::CssAssetUrlProcessor
       end
     end
 

--- a/test/test_css_asset_url_processor.rb
+++ b/test/test_css_asset_url_processor.rb
@@ -3,7 +3,7 @@ require 'sprockets/railtie'
 
 
 Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
-class TestAssetUrlProcessor < Minitest::Test
+class TestCssAssetUrlProcessor < Minitest::Test
   FIXTURES_PATH = File.expand_path("../fixtures", __FILE__)
 
   def setup
@@ -20,51 +20,51 @@ class TestAssetUrlProcessor < Minitest::Test
 
   def test_basic
     input = { environment: @env, data: 'background: url(logo.png);', filename: 'url2.css', metadata: {} }
-    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    output = Sprockets::Rails::CssAssetUrlProcessor.call(input)
     assert_equal("background: url(/logo-#{@logo_digest}.png);", output[:data])
   end
 
   def test_spaces
     input = { environment: @env, data: 'background: url( logo.png );', filename: 'url2.css', metadata: {} }
-    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    output = Sprockets::Rails::CssAssetUrlProcessor.call(input)
     assert_equal("background: url(/logo-#{@logo_digest}.png);", output[:data])
   end
 
   def test_single_quote
     input = { environment: @env, data: "background: url('logo.png');", filename: 'url2.css', metadata: {} }
-    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    output = Sprockets::Rails::CssAssetUrlProcessor.call(input)
     assert_equal("background: url(/logo-#{@logo_digest}.png);", output[:data])
   end
 
   def test_double_quote
     input = { environment: @env, data: 'background: url("logo.png");', filename: 'url2.css', metadata: {} }
-    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    output = Sprockets::Rails::CssAssetUrlProcessor.call(input)
     assert_equal("background: url(/logo-#{@logo_digest}.png);", output[:data])
   end
 
   def test_dependencies_are_tracked
     input = { environment: @env, data: 'background: url(logo.png);', filename: 'url2.css', metadata: {} }
-    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    output = Sprockets::Rails::CssAssetUrlProcessor.call(input)
     assert_equal(1, output[:links].size)
     assert_equal(@logo_uri, output[:links].first)
   end
 
   def test_relative
     input = { environment: @env, data: 'background: url(./logo.png);', filename: 'url2.css', metadata: {} }
-    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    output = Sprockets::Rails::CssAssetUrlProcessor.call(input)
     assert_equal("background: url(/logo-#{@logo_digest}.png);", output[:data])
   end
 
   def test_subdirectory
     input = { environment: @env, data: "background: url('jquery/jquery.js');", filename: 'url2.css', metadata: {} }
-    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    output = Sprockets::Rails::CssAssetUrlProcessor.call(input)
     jquery_digest = 'c6910e1db4a5ed4905be728ab786471e81565f4a9d544734b199f3790de9f9a3'
     assert_equal("background: url(/jquery/jquery-#{jquery_digest}.js);", output[:data])
   end
 
   def test_protocol_relative_paths
     input = { environment: @env, data: "background: url(//assets.example.com/assets/fontawesome-webfont-82ff0fe46a6f60e0ab3c4a9891a0ae0a1f7b7e84c625f55358379177a2dcb202.eot);", filename: 'url2.css', metadata: {} }
-    output = Sprockets::Rails::AssetUrlProcessor.call(input)
+    output = Sprockets::Rails::CssAssetUrlProcessor.call(input)
     assert_equal("background: url(//assets.example.com/assets/fontawesome-webfont-82ff0fe46a6f60e0ab3c4a9891a0ae0a1f7b7e84c625f55358379177a2dcb202.eot);", output[:data])
   end
 end

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -427,7 +427,7 @@ class TestRailtie < TestBoot
     app.initialize!
 
     assert_equal true, app.config.assets.resolve_assets_in_css_urls
-    assert_includes Sprockets.postprocessors['text/css'], Sprockets::Rails::AssetUrlProcessor
+    assert_includes Sprockets.postprocessors['text/css'], Sprockets::Rails::CssAssetUrlProcessor
   end
 
   def test_resolve_assets_in_css_urls_when_false_avoids_registering_postprocessor
@@ -437,7 +437,7 @@ class TestRailtie < TestBoot
     app.initialize!
 
     assert_equal false, app.config.assets.resolve_assets_in_css_urls
-    refute_includes Sprockets.postprocessors['text/css'], Sprockets::Rails::AssetUrlProcessor
+    refute_includes Sprockets.postprocessors['text/css'], Sprockets::Rails::CssAssetUrlProcessor
   end
 
   private


### PR DESCRIPTION
This processor only applies to CSS assets, so this name makes that clearer, and also has more symmetry with [`Propshaft::Compilers::CssAssetUrls`][1]

[1]: https://github.com/rails/propshaft/blob/9ca9fcfc415bdd3d49a2a9d809ca7859a95ec1f9/lib/propshaft/compilers/css_asset_urls.rb