### PR TITLE
Add rewriting of sourceMappingURL comment for css

### DIFF
--- a/lib/sprockets/rails/base_sourcemapping_url_processor.rb
+++ b/lib/sprockets/rails/base_sourcemapping_url_processor.rb
@@ -1,0 +1,47 @@
+module Sprockets
+  module Rails
+    class BaseSourcemappingUrlProcessor
+      class << self
+        def call(input)
+          env     = input[:environment]
+          context = env.context_class.new(input)
+          data    = input[:data].gsub(self::REGEX) do |_match|
+            sourcemap_logical_path = combine_sourcemap_logical_path(sourcefile: input[:name], sourcemap: $1)
+
+            begin
+              resolved_sourcemap_comment(sourcemap_logical_path, context: context)
+            rescue Sprockets::FileNotFound
+              removed_sourcemap_comment(sourcemap_logical_path, filename: input[:filename], env: env)
+            end
+          end
+
+          { data: data }
+        end
+
+        private
+          def combine_sourcemap_logical_path(sourcefile:, sourcemap:)
+            if (parts = sourcefile.split("/")).many?
+              parts[0..-2].append(sourcemap).join("/")
+            else
+              sourcemap
+            end
+          end
+
+          def sourcemap_asset_path(sourcemap_logical_path, context:)
+            # FIXME: Work-around for bug where if the sourcemap is nested two levels deep, it'll resolve as the source file
+            # that's being mapped, rather than the map itself. So context.resolve("a/b/c.js.map") will return "c.js?"
+            if context.resolve(sourcemap_logical_path) =~ /\.map/
+              context.asset_path(sourcemap_logical_path)
+            else
+              raise Sprockets::FileNotFound, "Failed to resolve source map asset due to nesting depth"
+            end
+          end
+
+          def removed_sourcemap_comment(sourcemap_logical_path, filename:, env:)
+            env.logger.warn "Removed sourceMappingURL comment for missing asset '#{sourcemap_logical_path}' from #{filename}"
+            nil
+          end
+      end
+    end
+  end
+end

--- a/lib/sprockets/rails/css_sourcemapping_url_processor.rb
+++ b/lib/sprockets/rails/css_sourcemapping_url_processor.rb
@@ -1,0 +1,18 @@
+module Sprockets
+  module Rails
+    # Rewrites source mapping urls with the digested paths and protect against semicolon appending with a dummy comment line
+    class CssSourcemappingUrlProcessor < BaseSourcemappingUrlProcessor
+      REGEX = %r{/\*# sourceMappingURL=(.*\.map)\s*\*/}
+
+      class << self
+
+        private
+
+          def resolved_sourcemap_comment(sourcemap_logical_path, context:)
+            "/*# sourceMappingURL=#{sourcemap_asset_path(sourcemap_logical_path, context: context)} */\n"
+          end
+
+      end
+    end
+  end
+end

--- a/lib/sprockets/rails/sourcemapping_url_processor.rb
+++ b/lib/sprockets/rails/sourcemapping_url_processor.rb
@@ -1,53 +1,17 @@
 module Sprockets
   module Rails
     # Rewrites source mapping urls with the digested paths and protect against semicolon appending with a dummy comment line
-    class SourcemappingUrlProcessor
+    class SourcemappingUrlProcessor < BaseSourcemappingUrlProcessor
       REGEX = /\/\/# sourceMappingURL=(.*\.map)/
 
       class << self
-        def call(input)
-          env     = input[:environment]
-          context = env.context_class.new(input)
-          data    = input[:data].gsub(REGEX) do |_match|
-            sourcemap_logical_path = combine_sourcemap_logical_path(sourcefile: input[:name], sourcemap: $1)
-
-            begin
-              resolved_sourcemap_comment(sourcemap_logical_path, context: context)
-            rescue Sprockets::FileNotFound
-              removed_sourcemap_comment(sourcemap_logical_path, filename: input[:filename], env: env)
-            end
-          end
-
-          { data: data }
-        end
 
         private
-          def combine_sourcemap_logical_path(sourcefile:, sourcemap:)
-            if (parts = sourcefile.split("/")).many?
-              parts[0..-2].append(sourcemap).join("/")
-            else
-              sourcemap
-            end
-          end
 
           def resolved_sourcemap_comment(sourcemap_logical_path, context:)
             "//# sourceMappingURL=#{sourcemap_asset_path(sourcemap_logical_path, context: context)}\n//!\n"
           end
 
-          def sourcemap_asset_path(sourcemap_logical_path, context:)
-            # FIXME: Work-around for bug where if the sourcemap is nested two levels deep, it'll resolve as the source file
-            # that's being mapped, rather than the map itself. So context.resolve("a/b/c.js.map") will return "c.js?"
-            if context.resolve(sourcemap_logical_path) =~ /\.map/
-              context.asset_path(sourcemap_logical_path)
-            else
-              raise Sprockets::FileNotFound, "Failed to resolve source map asset due to nesting depth"
-            end
-          end
-
-          def removed_sourcemap_comment(sourcemap_logical_path, filename:, env:)
-            env.logger.warn "Removed sourceMappingURL comment for missing asset '#{sourcemap_logical_path}' from #{filename}"
-            nil
-          end
       end
     end
   end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -6,6 +6,7 @@ require 'active_support/core_ext/numeric/bytes'
 require 'sprockets'
 
 require 'sprockets/rails/asset_url_processor'
+require 'sprockets/rails/base_sourcemapping_url_processor'
 require 'sprockets/rails/sourcemapping_url_processor'
 require 'sprockets/rails/context'
 require 'sprockets/rails/helper'

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -8,6 +8,7 @@ require 'sprockets'
 require 'sprockets/rails/asset_url_processor'
 require 'sprockets/rails/base_sourcemapping_url_processor'
 require 'sprockets/rails/sourcemapping_url_processor'
+require 'sprockets/rails/css_sourcemapping_url_processor'
 require 'sprockets/rails/context'
 require 'sprockets/rails/helper'
 require 'sprockets/rails/quiet_assets'
@@ -129,6 +130,7 @@ module Sprockets
 
     initializer :asset_sourcemap_url_processor do |app|
       Sprockets.register_postprocessor "application/javascript", ::Sprockets::Rails::SourcemappingUrlProcessor
+      Sprockets.register_postprocessor "text/css", ::Sprockets::Rails::CssSourcemappingUrlProcessor
     end
 
     config.assets.version     = ""

--- a/test/test_css_sourcemapping_url_processor.rb
+++ b/test/test_css_sourcemapping_url_processor.rb
@@ -1,0 +1,49 @@
+require 'minitest/autorun'
+require 'sprockets/railtie'
+
+Minitest::Test = MiniTest::Unit::TestCase unless defined?(Minitest::Test)
+class TestCssSourceMappingUrlProcessor < Minitest::Test
+  def setup
+    @env = Sprockets::Environment.new
+  end
+
+  def test_successful
+    @env.context_class.class_eval do
+      def resolve(path, **kargs)
+        "/assets/mapped.css.map"
+      end
+
+      def asset_path(path, options = {})
+        "/assets/mapped-HEXGOESHERE.css.map"
+      end
+    end
+
+    input = { environment: @env, data: "div {\ndisplay: none;\n}\n/*# sourceMappingURL=mapped.css.map */", name: 'mapped', filename: 'mapped.css', metadata: {} }
+    output = Sprockets::Rails::CssSourcemappingUrlProcessor.call(input)
+    assert_equal({ data: "div {\ndisplay: none;\n}\n/*# sourceMappingURL=/assets/mapped-HEXGOESHERE.css.map */\n" }, output)
+  end
+
+  def test_resolving_erroneously_without_map_extension
+    @env.context_class.class_eval do
+      def resolve(path, **kargs)
+        "/assets/mapped.css"
+      end
+    end
+
+    input = { environment: @env, data: "div {\ndisplay: none;\n}\n/*# sourceMappingURL=mapped.css.map */", name: 'mapped', filename: 'mapped.css', metadata: {} }
+    output = Sprockets::Rails::CssSourcemappingUrlProcessor.call(input)
+    assert_equal({ data: "div {\ndisplay: none;\n}\n" }, output)
+  end
+
+  def test_missing
+    @env.context_class.class_eval do
+      def resolve(path, **kargs)
+        raise Sprockets::FileNotFound
+      end
+    end
+
+    input = { environment: @env, data: "div {\ndisplay: none;\n}\n/*# sourceMappingURL=mappedNOT.css.map */", name: 'mapped', filename: 'mapped.css', metadata: {} }
+    output = Sprockets::Rails::CssSourcemappingUrlProcessor.call(input)
+    assert_equal({ data: "div {\ndisplay: none;\n}\n" }, output)
+  end
+end


### PR DESCRIPTION
Previously only javascript files had their sourceMappingURL comments rewritten with the digested asset location. This PR adds the same treatment to sourceMappingURL comments in css files