### PR TITLE
Fix sourcemap with path prefix when using esbuild with publicPath

### DIFF
--- a/lib/sprockets/rails/sourcemapping_url_processor.rb
+++ b/lib/sprockets/rails/sourcemapping_url_processor.rb
@@ -23,7 +23,7 @@ module Sprockets
 
         private
           def combine_sourcemap_logical_path(sourcefile:, sourcemap:)
-            if (parts = sourcefile.split("/")).many?
+            if (parts = sourcefile.split("/")).many? && !sourcemap.split("/").many?
               parts[0..-2].append(sourcemap).join("/")
             else
               sourcemap


### PR DESCRIPTION
Esbuild puts the `publicPath` as a prefix in the `sourceMappingURL` and because I am using `editor/editor` to generate the script tag sprockets-rails generating the wrong path and removing the `sourceMappingURL` from the compiled file.
```
 <%= javascript_include_tag 'editor/editor', defer: true, integrity: true, crossorigin: "anonymous" %>
```

```
// build.js
esbuild
  .build({
    bundle: true,
    sourcemap: true,
    format: 'esm',
    outdir: path.join(process.cwd(), '../../app/assets/builds/editor'),
    publicPath: './editor',
    entryPoints: ['packs/editor.js'],
    ...
 ```
 
```
//  app/assets/builds/editor/editor.js
.
.
.
//# sourceMappingURL=editor/editor.js.map
```

This PR fixes it by only running the special case path when `sourceMappingURL` does not have a directory prefix. 
