### PR TITLE
Update rails/sprockets default branch from master to main

### DIFF
--- a/gemfiles/Gemfile.rails-5.2.x.sprockets-4.x
+++ b/gemfiles/Gemfile.rails-5.2.x.sprockets-4.x
@@ -4,4 +4,4 @@ gemspec path: '..'
 
 gem 'actionpack', '~> 5.2.0'
 gem 'railties', '~> 5.2.0'
-gem 'sprockets', github: 'rails/sprockets', branch: 'master'
+gem 'sprockets', github: 'rails/sprockets', branch: 'main'

--- a/gemfiles/Gemfile.rails-6.0.x.sprockets-4.x
+++ b/gemfiles/Gemfile.rails-6.0.x.sprockets-4.x
@@ -4,4 +4,4 @@ gemspec path: '..'
 
 gem 'actionpack', '~> 6.0.0'
 gem 'railties', '~> 6.0.0'
-gem 'sprockets', github: 'rails/sprockets', branch: 'master'
+gem 'sprockets', github: 'rails/sprockets', branch: 'main'


### PR DESCRIPTION
This pull request addresses this bundle install failure that is used in CI.

```ruby
% BUNDLE_GEMFILE=gemfiles/Gemfile.rails-6.0.x.sprockets-4.x bundle install
Fetching https://github.com/rails/sprockets.git
fatal: Needed a single revision
Git error: command `git rev-parse --verify master` in directory
/Users/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/cache/bundler/git/sprockets-67c51ee2a2e0410ca1e13d6e1277668b7a11b6c3 has
failed.
Revision master does not exist in the repository https://github.com/rails/sprockets.git. Maybe you misspelled it?
If this error persists you could try removing the cache directory
'/Users/yahonda/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/cache/bundler/git/sprockets-67c51ee2a2e0410ca1e13d6e1277668b7a11b6c3'
%
```