### PR TITLE
In url() prevent relative path from being converted to root absolute path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile*.lock
 tmp/
 *.gem
+.idea

--- a/lib/sprockets/rails/asset_url_processor.rb
+++ b/lib/sprockets/rails/asset_url_processor.rb
@@ -7,7 +7,14 @@ module Sprockets
         context = input[:environment].context_class.new(input)
         data    = input[:data].gsub(REGEX) do |_match|
           path = Regexp.last_match[:path]
-          "url(#{context.asset_path(path)})"
+          # original: "url(#{context.asset_path(path)})"
+
+          # Prevent non-digest relative path from being converted to root absolute path
+          orig_path = path
+          path = context.asset_path(path)
+          path = (path == "/#{orig_path}") ? ".#{path}" : path
+          "url(#{path})"
+
         end
 
         context.metadata.merge(data: data)


### PR DESCRIPTION
Prevent non-digest  (not assets pipeline) relative path from being converted to root absolute path. Prevent convert url() in attached third-party css-styles libraries.