### PR TITLE
Fix broken sourcemaps when using `esbuild --public-path`

### DIFF
--- a/lib/sprockets/rails/sourcemapping_url_processor.rb
+++ b/lib/sprockets/rails/sourcemapping_url_processor.rb
@@ -2,7 +2,7 @@ module Sprockets
   module Rails
     # Rewrites source mapping urls with the digested paths and protect against semicolon appending with a dummy comment line
     class SourcemappingUrlProcessor
-      REGEX = /\/\/# sourceMappingURL=(.*\.map)/
+      REGEX = /\/\/# sourceMappingURL=(?:.*\/)?(.*\.map)/
 
       class << self
         def call(input)


### PR DESCRIPTION
When the [--public-path option was added to esbuild](https://github.com/rails/jsbundling-rails/pull/58) it broke Sprockets's ability to resolve sourcemaps, even though they're still present.

Esbuild's sourcemap output with `--public-path=assets`:
`//# sourceMappingURL=assets/application.js.map`

Esbuild's sourcemap output without `--public-path`:
`//# sourceMappingURL=application.js.map`

It's desirable to keep `--public-path=assets` for properly resolving static assets in JavaScript files, but the leading directory in `sourceMappingURL` is undesirable, or at least it does not work with Sprockets.

This PR allows `sourceMappingURL=` to contain a leading, optional directory which is ignored as the path is resolved.

This is an alternative to #501. (Sorry, I didn't see it until after I found this solution.)

