### PR TITLE
CI against Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,19 @@ jobs:
             gemfile: "gemfiles/Gemfile.rails-6.0.x.sprockets-4.x"
           - ruby: 3.1
             gemfile: "gemfiles/Gemfile.rails-6.1.x.sprockets-4.x"
+          - ruby: 3.2
+            gemfile: "gemfiles/Gemfile.rails-6.0.x"
+          - ruby: 3.2
+            gemfile: "gemfiles/Gemfile.rails-6.0.x.sprockets-4.x"
+          - ruby: 3.2
+            gemfile: "gemfiles/Gemfile.rails-6.1.x.sprockets-4.x"
           - ruby: 2.7
             gemfile: Gemfile
           - ruby: '3.0'
             gemfile: Gemfile
           - ruby: '3.1'
+            gemfile: Gemfile
+          - ruby: 3.2
             gemfile: Gemfile
           - ruby: head
             gemfile: Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gemspec
 
 gem 'actionpack', github: 'rails/rails', branch: 'main'
 gem 'railties', github: 'rails/rails', branch: 'main'
-gem 'rack', github: 'rack/rack', branch: 'master', ref: "e84bb296d1a16b32159608596f1f5a23b2016633"
+gem 'rack', '~> 2.2'
 gem 'sprockets', github: 'rails/sprockets', branch: '3.x'


### PR DESCRIPTION
Also, this patch fixes CI failure on current master branch by fixing Gemfile referencing non-existing rack branch.