### PR TITLE
Handle Inline Sourcemaps

### DIFF
--- a/test/test_sourcemapping_url_processor.rb
+++ b/test/test_sourcemapping_url_processor.rb
@@ -46,4 +46,16 @@ class TestSourceMappingUrlProcessor < Minitest::Test
     output = Sprockets::Rails::SourcemappingUrlProcessor.call(input)
     assert_equal({ data: "var mapped;\n" }, output)
   end
+
+  def test_inline_successful
+    @env.context_class.class_eval do
+      def resolve(path, **kargs)
+        "/assets/mapped.js.map"
+      end
+    end
+
+    input = { environment: @env, data: "var mapped;\n//# sourceMappingURL=data:application/json;base64,abc123=", name: 'mapped', filename: 'mapped.js', metadata: {} }
+    output = Sprockets::Rails::SourcemappingUrlProcessor.call(input)
+    assert_equal({ data: "var mapped;\n//# sourceMappingURL=data:application/json;base64,abc123=\n//!\n" }, output)
+  end
 end


### PR DESCRIPTION
# Description
Sprockets gem appends semicolons to each js asset which corrupts `//# sourceMappingURL=` magic comments. `sprockets-rails` fixes this by appending `\n//!\n` to the asset so the `sourceMappingURL` is not the last line and in turn not corrupted by the semicolon. This only applies to external sourcemap files.

This PR improves `SourcemappingUrlProcessor` to also add `\n//!\n` after `sourceMappingURL` comments when they contain inline sourcemaps.