### PR TITLE
Require sprockets deprecator in Railtie

### DIFF
--- a/lib/sprockets/rails.rb
+++ b/lib/sprockets/rails.rb
@@ -1,13 +1,5 @@
 require 'sprockets/rails/version'
-require 'active_support'
 if defined? Rails::Railtie
   require 'sprockets/railtie'
 end
-
-module Sprockets
-  module Rails
-    def self.deprecator
-      @deprecator ||= ActiveSupport::Deprecation.new("4.0", "Sprockets::Rails")
-    end
-  end
-end
+require 'sprockets/rails/deprecator'

--- a/lib/sprockets/rails/deprecator.rb
+++ b/lib/sprockets/rails/deprecator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "active_support"
+
+module Sprockets
+  module Rails
+    def self.deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new("4.0", "Sprockets::Rails")
+    end
+  end
+end

--- a/lib/sprockets/railtie.rb
+++ b/lib/sprockets/railtie.rb
@@ -6,6 +6,7 @@ require 'active_support/core_ext/numeric/bytes'
 require 'sprockets'
 
 require 'sprockets/rails/asset_url_processor'
+require 'sprockets/rails/deprecator'
 require 'sprockets/rails/sourcemapping_url_processor'
 require 'sprockets/rails/context'
 require 'sprockets/rails/helper'


### PR DESCRIPTION
With the release of sprockets-rails 3.5.0, our local test suite breaks with

```
NoMethodError:
  undefined method `deprecator' for Sprockets::Rails:Module
 /home/circleci/solidus/vendor/bundle/ruby/3.2.0/gems/sprockets-rails-3.5.0/lib/sprockets/railtie.rb:129:in `block in <class:Railtie>'
```

This should fix that by explicitly requiring the
`Sprockets::Rails.deprecator` in both `lib/sprockets/rails.rb` and `lib/sprockets/railtie.rb`.

Fix #524