### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/sprockets-rails

### DIFF
--- a/sprockets-rails.gemspec
+++ b/sprockets-rails.gemspec
@@ -23,4 +23,6 @@ Gem::Specification.new do |s|
 
   s.author = "Joshua Peek"
   s.email  = "josh@joshpeek.com"
+
+  s.metadata["changelog_uri"] = "https://github.com/rails/sprockets-rails/releases"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/sprockets-rails which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/