### PR TITLE
Prevent regressions with requiring sprockets/railtie

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,9 @@ require 'minitest/autorun'
 
 require 'action_view'
 require 'sprockets'
-require 'sprockets/rails'
+# Apps generated before Rails 7.0 without rails/all require sprockets/railtie, not sprockets/rails
+# Same with other reverse dependencies like sassc-rails
+require 'sprockets/railtie'
 require 'sprockets/rails/context'
 require 'sprockets/rails/helper'
 require 'rails/version'


### PR DESCRIPTION
Some applications or gems don't require sprockets/rails, instead they load sprockets/railtie.

This change catches this issue when running tests.

```console
$ git checkout v3.5.0
HEAD is now at 5f6d88d Release 3.5.0
$ git cherry-pick --no-commit prevent-regression-for-sprockets-railtie 
$ bundle exec rake >/dev/null 2>&1 || echo failed
failed
```