### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/sprockets-rails.gemspec
+++ b/sprockets-rails.gemspec
@@ -9,6 +9,10 @@ Gem::Specification.new do |s|
   s.summary  = "Sprockets Rails integration"
   s.license  = "MIT"
 
+  s.metadata = {
+    "changelog_uri" => "#{s.homepage}/releases/tag/v#{s.version}"
+  }
+
   s.files = Dir["README.md", "lib/**/*.rb", "MIT-LICENSE"]
 
   s.required_ruby_version = '>= 2.5'


### PR DESCRIPTION
Documented here: https://guides.rubygems.org/specification-reference/#metadata 

Useful for running https://github.com/MaximeD/gem_updater