### PR TITLE
Use `<<~ `(squiggly heredoc) to address `warning: literal string will be frozen in the future`

### DIFF
--- a/lib/sprockets/rails/quiet_assets.rb
+++ b/lib/sprockets/rails/quiet_assets.rb
@@ -20,10 +20,14 @@ module Sprockets
 
       private
         def raise_logger_silence_error
-          error = "You have enabled `config.assets.quiet`, but your `Rails.logger`\n"
-          error << "does not use the `LoggerSilence` module.\n\n"
-          error << "Please use a compatible logger such as `ActiveSupport::Logger`\n"
-          error << "to take advantage of quiet asset logging.\n\n"
+          error = <<~ERROR
+            You have enabled `config.assets.quiet`, but your `Rails.logger`
+            does not use the `LoggerSilence` module.
+
+            Please use a compatible logger such as `ActiveSupport::Logger`
+            to take advantage of quiet asset logging.
+
+          ERROR
 
           raise LoggerSilenceError, error
         end


### PR DESCRIPTION
This commit addresses the `warning: literal string will be frozen in the future` against Ruby 3.4.0dev

```$ ruby -v
ruby 3.4.0dev (2024-10-21T16:48:53Z master 5131fb5dbe) +PRISM [x86_64-linux]
$ RUBYOPT="--debug-frozen-string-literal" bundle exec rake test TEST=test/test_quiet_assets.rb
```

- Warnings addressed by this commit
```ruby
/path/to/sprockets-rails/lib/sprockets/rails/quiet_assets.rb:24: warning: literal string will be frozen in the future
/path/to/sprockets-rails/lib/sprockets/rails/quiet_assets.rb:23: info: the string was created here
```

- Sprockets Rails requires Ruby 2.5 that supports `<<~` (squiggly heredoc) introduced since Ruby 2.3.

https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/ https://github.com/ruby/ruby/blob/d40ea2afa6ff5a6e5befcf342fb7b6dc58796b20/NEWS?plain=1#L53-L57 https://github.com/ruby/ruby/pull/11893

- `--debug-frozen-string-literal` option has been introduced via https://github.com/ruby/ruby/pull/11893