### PR TITLE
Warn instead of raising on missing `manifest.js`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,35 +9,43 @@ jobs:
         include:
           - ruby: 2.5
             gemfile: "gemfiles/Gemfile.rails-6.1-sprockets-3"
+            bundler: "2.3.0"
           - ruby: 2.5
             gemfile: "gemfiles/Gemfile.rails-6.1-sprockets-4"
-
+            bundler: "2.3.0"
           - ruby: 2.7
             gemfile: "gemfiles/Gemfile.rails-7.0-sprockets-3"
+            bundler: "2.4.8"
           - ruby: 2.7
             gemfile: "gemfiles/Gemfile.rails-7.0-sprockets-4"
-
+            bundler: "2.4.8"
           - ruby: 2.7
             gemfile: "gemfiles/Gemfile.rails-7.1-sprockets-3"
+            bundler: "2.4.8"
           - ruby: 2.7
             gemfile: "gemfiles/Gemfile.rails-7.1-sprockets-4"
-
+            bundler: "2.4.8"
           - ruby: 3.1
             gemfile: "gemfiles/Gemfile.rails-7.2-sprockets-3"
+            bundler: default
           - ruby: 3.1
             gemfile: "gemfiles/Gemfile.rails-7.2-sprockets-4"
-
+            bundler: default
           - ruby: 3.2
             gemfile: "gemfiles/Gemfile.rails-8.0-sprockets-3"
+            bundler: default
           - ruby: 3.2
             gemfile: "gemfiles/Gemfile.rails-8.0-sprockets-4"
-
+            bundler: default
           - ruby: 3.2
             gemfile: Gemfile
+            bundler: default
           - ruby: 3.3
             gemfile: Gemfile
+            bundler: default
           - ruby: head
             gemfile: Gemfile
+            bundler: default
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
@@ -49,6 +57,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          cache-version: ${{ matrix.ruby }}-${{ matrix.ruby }}-${{ matrix.gemfile }}
+          bundler: ${{ matrix.bundler }}
       - name: Run tests
         run: bundle exec rake
         continue-on-error: ${{ matrix.gemfile == 'Gemfile' }}

--- a/gemfiles/Gemfile.rails-6.1-sprockets-3
+++ b/gemfiles/Gemfile.rails-6.1-sprockets-3
@@ -4,3 +4,5 @@ gemspec path: '..'
 gem 'actionpack', '~> 6.1.0'
 gem 'railties', '~> 6.1.0'
 gem 'sprockets', '~> 3.0'
+
+gem 'concurrent-ruby', '< 1.3.5'

--- a/gemfiles/Gemfile.rails-6.1-sprockets-4
+++ b/gemfiles/Gemfile.rails-6.1-sprockets-4
@@ -4,3 +4,5 @@ gemspec path: '..'
 gem 'actionpack', '~> 6.1.0'
 gem 'railties', '~> 6.1.0'
 gem 'sprockets', '~> 4.0'
+
+gem 'concurrent-ruby', '< 1.3.5'

--- a/gemfiles/Gemfile.rails-7.0-sprockets-3
+++ b/gemfiles/Gemfile.rails-7.0-sprockets-3
@@ -4,3 +4,5 @@ gemspec path: '..'
 gem 'actionpack', '~> 7.0.0'
 gem 'railties', '~> 7.0.0'
 gem 'sprockets', '~> 3.0'
+
+gem 'concurrent-ruby', '< 1.3.5'

--- a/gemfiles/Gemfile.rails-7.0-sprockets-4
+++ b/gemfiles/Gemfile.rails-7.0-sprockets-4
@@ -4,3 +4,5 @@ gemspec path: '..'
 gem 'actionpack', '~> 7.0.0'
 gem 'railties', '~> 7.0.0'
 gem 'sprockets', '~> 4.0'
+
+gem 'concurrent-ruby', '< 1.3.5'


### PR DESCRIPTION
With a pristine (`rails new`) Rails 8.0 app, the `app/assets/config/manifest.js` file is no longer automatically generated. For engines still using sprockets, that is not a huge issue, because they [have and add their own manifest files](https://github.com/solidusio/solidus/blob/main/backend/config/initializers/assets.rb) for their assets to the list of precompiled assets.

However, scripts like the [Solidus bin/sandbox script](https://github.com/solidusio/solidus/blob/main/bin/sandbox#L44-L99) first run `rails new`, then add the needed engines to the sandbox's `Gemfile`, then run `rails db:migrate` and their respective install generators. With Rails 8, these scripts now fail before anything is possible in Ruby, because the initializer of `Sprockets::Railtie` will raise an error on startup.

This commit changes the behavior of the Railtie to issue a deprecation warning instead of raising an Exception.