### PR TITLE
CI: Specify Bundler version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,35 +9,43 @@ jobs:
         include:
           - ruby: 2.5
             gemfile: "gemfiles/Gemfile.rails-6.1-sprockets-3"
+            bundler: "2.3.0"
           - ruby: 2.5
             gemfile: "gemfiles/Gemfile.rails-6.1-sprockets-4"
-
+            bundler: "2.3.0"
           - ruby: 2.7
             gemfile: "gemfiles/Gemfile.rails-7.0-sprockets-3"
+            bundler: "2.4.8"
           - ruby: 2.7
             gemfile: "gemfiles/Gemfile.rails-7.0-sprockets-4"
-
+            bundler: "2.4.8"
           - ruby: 2.7
             gemfile: "gemfiles/Gemfile.rails-7.1-sprockets-3"
+            bundler: "2.4.8"
           - ruby: 2.7
             gemfile: "gemfiles/Gemfile.rails-7.1-sprockets-4"
-
+            bundler: "2.4.8"
           - ruby: 3.1
             gemfile: "gemfiles/Gemfile.rails-7.2-sprockets-3"
+            bundler: default
           - ruby: 3.1
             gemfile: "gemfiles/Gemfile.rails-7.2-sprockets-4"
-
+            bundler: default
           - ruby: 3.2
             gemfile: "gemfiles/Gemfile.rails-8.0-sprockets-3"
+            bundler: default
           - ruby: 3.2
             gemfile: "gemfiles/Gemfile.rails-8.0-sprockets-4"
-
+            bundler: default
           - ruby: 3.2
             gemfile: Gemfile
+            bundler: default
           - ruby: 3.3
             gemfile: Gemfile
+            bundler: default
           - ruby: head
             gemfile: Gemfile
+            bundler: default
 
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
@@ -49,6 +57,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          cache-version: ${{ matrix.ruby }}-${{ matrix.ruby }}-${{ matrix.gemfile }}
+          bundler: ${{ matrix.bundler }}
       - name: Run tests
         run: bundle exec rake
         continue-on-error: ${{ matrix.gemfile == 'Gemfile' }}

--- a/gemfiles/Gemfile.rails-6.1-sprockets-3
+++ b/gemfiles/Gemfile.rails-6.1-sprockets-3
@@ -4,3 +4,5 @@ gemspec path: '..'
 gem 'actionpack', '~> 6.1.0'
 gem 'railties', '~> 6.1.0'
 gem 'sprockets', '~> 3.0'
+
+gem 'concurrent-ruby', '< 1.3.5'

--- a/gemfiles/Gemfile.rails-6.1-sprockets-4
+++ b/gemfiles/Gemfile.rails-6.1-sprockets-4
@@ -4,3 +4,5 @@ gemspec path: '..'
 gem 'actionpack', '~> 6.1.0'
 gem 'railties', '~> 6.1.0'
 gem 'sprockets', '~> 4.0'
+
+gem 'concurrent-ruby', '< 1.3.5'

--- a/gemfiles/Gemfile.rails-7.0-sprockets-3
+++ b/gemfiles/Gemfile.rails-7.0-sprockets-3
@@ -4,3 +4,5 @@ gemspec path: '..'
 gem 'actionpack', '~> 7.0.0'
 gem 'railties', '~> 7.0.0'
 gem 'sprockets', '~> 3.0'
+
+gem 'concurrent-ruby', '< 1.3.5'

--- a/gemfiles/Gemfile.rails-7.0-sprockets-4
+++ b/gemfiles/Gemfile.rails-7.0-sprockets-4
@@ -4,3 +4,5 @@ gemspec path: '..'
 gem 'actionpack', '~> 7.0.0'
 gem 'railties', '~> 7.0.0'
 gem 'sprockets', '~> 4.0'
+
+gem 'concurrent-ruby', '< 1.3.5'


### PR DESCRIPTION
Bundler `latest` has stopped working with older Rubies. We need to specify the Bundler version for the older Rubies to still build.

Also adds the `concurrent-ruby` limit to `< 1.3.5` for Rails 6.1 and 7.0.