### PR TITLE
Document config.assets.gzip option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Enable asset debugging mode. A source map will be included with each asset when 
 
 Enables Sprockets compile environment. If disabled, `Rails.application.assets` will be `nil` to prevent inadvertent compilation calls. View helpers will depend on assets being precompiled to `public/assets` in order to link to them. Initializers expecting `Rails.application.assets` during boot should be accessing the environment in a `config.assets.configure` block. See below.
 
+**`config.assets.gzip`**
+
+Enabled by default, when Sprockets generates a compiled asset file it will also produce a gzipped copy of that file. Sprockets only gzips non-binary files such as CSS, javascript, and SVG files.
+
 **`config.assets.configure`**
 
 Invokes block with environment when the environment is initialized. Allows direct access to the environment instance and lets you lazily load libraries only needed for asset compiling.


### PR DESCRIPTION
I noticed that this option was not documented in the Readme, though seems to be [used somewhat commonly](https://github.com/search?type=code&q=%22gzip+%3D+false%22+path%3Aconfig%2F+language%3ARuby).

I adapted [the Sprockets documentation](https://github.com/rails/sprockets/blob/4dff018b9271c37b09889e829f8926d1c5379731/README.md?plain=1#L674) which says "This behavior can be disabled, refer to your framework specific documentation." 